### PR TITLE
FIX: use of kwargs on Sofa.Controller's ctors

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -203,9 +203,9 @@ void BindingBase::SetAttr(Base& self, const std::string& s, py::object value)
         return;
     }
 
-    /// Well this should never happen unless there is no __dict__
-    /// @TODO : clean msg
-    throw py::attribute_error(self.name.getValue() + "has no __dict__");
+    /// IMHO (@marques-bruno): this will ALWAYS happen (if not data / link is already exising with name "s")
+    /// since 'self' is not a py::object and thus has no __dict__:
+//    throw py::attribute_error(self.name.getValue() + " has no __dict__");
 }
 
 void BindingBase::SetDataFromArray(BaseData* data, const py::array& value)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -203,9 +203,7 @@ void BindingBase::SetAttr(Base& self, const std::string& s, py::object value)
         return;
     }
 
-    /// IMHO (@marques-bruno): this will ALWAYS happen (if not data / link is already exising with name "s")
-    /// since 'self' is not a py::object and thus has no __dict__:
-//    throw py::attribute_error(self.name.getValue() + " has no __dict__");
+    throw py::attribute_error(self.name.getValue() + " has no data field nor link named '" + s + "'");
 }
 
 void BindingBase::SetDataFromArray(BaseData* data, const py::array& value)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -87,14 +87,17 @@ namespace sofapython3
 
                   if(args.size() != 0)
                   {
-                      if(args.size()==1) c->setName(py::cast<std::string>(args[0]));
-                      else throw py::type_error("Only one un-named arguments can be provided.");
+                      if(args.size()>=1) c->setName(py::cast<std::string>(args[0]));
+                      /// Why? It's not useful for datafield creation, but could totally be used internally,
+                      /// as a std python positional param
+//                      else throw py::type_error("Only one un-named arguments can be provided.");
                   }
 
                   for(auto kv : kwargs)
                   {
                       std::string key = py::cast<std::string>(kv.first);
                       py::object value = py::object(kv.second, true);
+
                       if( key == "name")
                       {
                           if( args.size() != 0 )
@@ -106,7 +109,6 @@ namespace sofapython3
                       }
                       BindingBase::SetAttr(*c, key, value);
                   }
-
                   return c;
               }));
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -22,8 +22,8 @@ namespace sofapython3
 
 py::module addSubmoduleSimulation(py::module &m)
 {
-//    if(!sofa::simulation::getSimulation())
-    sofa::simulation::setSimulation(new DAGSimulation());
+    if(!sofa::simulation::getSimulation())
+        sofa::simulation::setSimulation(new DAGSimulation());
 
     py::module simulation = m.def_submodule("Simulation");
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -22,8 +22,8 @@ namespace sofapython3
 
 py::module addSubmoduleSimulation(py::module &m)
 {
-    if(!sofa::simulation::getSimulation())
-        sofa::simulation::setSimulation(new DAGSimulation());
+//    if(!sofa::simulation::getSimulation())
+    sofa::simulation::setSimulation(new DAGSimulation());
 
     py::module simulation = m.def_submodule("Simulation");
 

--- a/bindings/Sofa/tests/Core/Controller.py
+++ b/bindings/Sofa/tests/Core/Controller.py
@@ -8,6 +8,9 @@ class MyController(Sofa.Controller):
         """This is my custom controller
            when init is called from Sofa this should call the python init function
         """        
+
+        onAnimateEndEvent = "check that handleEvent falls back on onEvent even \
+                             when a non-callable holds the name of an event"
         def __init__(self, *args, **kwargs):
             ## These are needed (and the normal way to override from a python class)
             Sofa.Controller.__init__(self, *args, **kwargs)
@@ -23,11 +26,10 @@ class MyController(Sofa.Controller):
                 self.inited += 1
 
         def onEvent(self, event):
-                Sofa.Controller.handleEvent(self, event)
-                print(" HandleEvent" )
+                print(" Handling event " + str(event))
 
         def onAnimateBeginEvent(self, other):
-                print(" Python::onAnimationBeginEvent() at "+str(other))
+                print(" Python::onAnimationBeginEvent() ("+str(other) + ")")
                 self.iterations+=1
 
 
@@ -39,7 +41,7 @@ class Test(unittest.TestCase):
 
          def test_constructorOverriden(self):
                  root = Sofa.Node("rootNode")
-                 root.addObject(MyController("controller"))
+                 root.addObject(MyController(name="controller"))
                  root.controller.init()
                  root.controller.reinit()
 
@@ -56,7 +58,7 @@ class Test(unittest.TestCase):
                  dynamically in its init and reinit function. And that after the
                  call the attributes are still available.
                  """
-                 c = MyController("controller")
+                 c = MyController(name="controller")
 
                  self.assertTrue( hasattr(c, "inited") )
                  c.init()
@@ -69,6 +71,7 @@ class Test(unittest.TestCase):
             node = Sofa.Node("root")
             node.addObject("DefaultAnimationLoop", name="loop")
             controller = node.addObject( MyController() )
+
 
             self.assertTrue( hasattr(controller, "iterations") )
 
@@ -86,7 +89,7 @@ class Test(unittest.TestCase):
                     holding a reference to the python object.
                  """
                  node = Sofa.Node("root")
-                 node.addObject( MyController("controller") )
+                 node.addObject( MyController(name="controller") )
                  node.init()
 
                  ## At this step we can validate that the python side is ok.

--- a/bindings/Sofa/tests/Core/Controller.py
+++ b/bindings/Sofa/tests/Core/Controller.py
@@ -9,11 +9,11 @@ class MyController(Sofa.Controller):
            when init is called from Sofa this should call the python init function
         """        
         def __init__(self, *args, **kwargs):
-                ## These are needed (and the normal way to override from a python class)
-                Sofa.Controller.__init__(self, *args, **kwargs)
-                print(" Python::__init__::"+str(self.name))
-                self.inited = 0
-                self.iterations = 0
+            ## These are needed (and the normal way to override from a python class)
+            Sofa.Controller.__init__(self, *args, **kwargs)
+            print(" Python::__init__::"+str(self.name))
+            self.inited = 0
+            self.iterations = 0
 
         def __del__(self):
                 print(" Python::__del__")
@@ -30,14 +30,6 @@ class MyController(Sofa.Controller):
                 print(" Python::onAnimationBeginEvent() at "+str(other))
                 self.iterations+=1
 
-class MyController2(Sofa.Controller):
-    """This is another custom controller
-       it can take arguments as parameters (or can it..?)
-    """
-    def __init__(self, *args, **kw):
-        print ("Simple arguments list: " + str(args))
-        print ("Keyword arguments list: " + str(kw))
-
 
 class Test(unittest.TestCase):
          def test_constructor(self):
@@ -53,11 +45,11 @@ class Test(unittest.TestCase):
 
          def test_constructorOverriddenWithArgs(self):
              root = Sofa.Node("rootNode")
-             root.addObject(MyController("controller", "value"))
+             root.addObject(MyController("controller", "pval1", "pval2", "pval3"))
 
          def test_constructorOverriddenWithKWArgs(self):
              root = Sofa.Node("rootNode")
-             root.addObject(MyController("controller", an_argument="value2"))
+             root.addObject(MyController("controller", kval1="value1", kval2="value2", kval3="value3"))
 
          def test_methodOverriding(self):
                  """Test that a custom controller 'MyController' correctly adds attributes when overridden.


### PR DESCRIPTION
This PR fixes the use of args & kwargs in Controller's __init__.
It seems to me that it was purposely prevented in the previous implementation, hence the pull request.
Idk what are the drawbacks of enabling this (apart from the potential confusion of maybe expecting the kwarg to be converted into a datafield..? :/