### PR TITLE
ADD: binding of event data as dict for the controllers

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -8,6 +8,33 @@
 #include <sofa/core/objectmodel/Event.h>
 using sofa::core::objectmodel::Event;
 
+
+#include "sofa/simulation/AnimateBeginEvent.h"
+using sofa::simulation::AnimateBeginEvent;
+#include "sofa/simulation/AnimateEndEvent.h"
+using sofa::simulation::AnimateEndEvent;
+//#include "sofa/simulation/CollisionBeginEvent.h"
+//#include "sofa/simulation/CollisionEndEvent.h"
+//#include "sofa/simulation/IntegrateBeginEvent.h"
+//#include "sofa/simulation/IntegrateEndEvent.h"
+//#include "sofa/simulation/PauseEvent.h"
+//#include "sofa/simulation/PositionEvent.h"
+//#include "sofa/simulation/UpdateMappingEndEvent.h"
+
+//#include "sofa/core/objectmodel/DetachNodeEvent.h"
+//#include "sofa/core/objectmodel/GUIEvent.h"
+//#include "sofa/core/objectmodel/HapticDeviceEvent.h"
+//#include "sofa/core/objectmodel/IdleEvent.h"
+//#include "sofa/core/objectmodel/JoystickEvent.h"
+#include "sofa/core/objectmodel/KeypressedEvent.h"
+using sofa::core::objectmodel::KeypressedEvent;
+#include "sofa/core/objectmodel/KeyreleasedEvent.h"
+using sofa::core::objectmodel::KeyreleasedEvent;
+#include "sofa/core/objectmodel/MouseEvent.h"
+using sofa::core::objectmodel::MouseEvent;
+#include "sofa/core/objectmodel/ScriptEvent.h"
+using sofa::core::objectmodel::ScriptEvent;
+
 PYBIND11_DECLARE_HOLDER_TYPE(Controller,
                              sofapython3::py_shared_ptr<Controller>, true)
 
@@ -39,7 +66,18 @@ namespace sofapython3
         virtual void init() override ;
         virtual void reinit() override ;
         virtual void handleEvent(Event* event) override ;
+
+    private:
+        void callScriptMethod(const py::object& self, Event* event,
+                              std::string methodName);
+        void initEventDict(std::vector<std::function<py::object(Event*)> >&);
+        static std::vector<std::function<py::object(Event*)> > s_getEventDict;
+        static bool s_isDictCreated;
+
     };
+
+    bool Controller_Trampoline::s_isDictCreated = false;
+    std::vector<std::function<py::object(Event*)> > Controller_Trampoline::s_getEventDict = std::vector<std::function<py::object(Event*)> >();
 
     void Controller_Trampoline::init()
     {
@@ -51,8 +89,94 @@ namespace sofapython3
         PYBIND11_OVERLOAD(void, Controller, reinit, );
     }
 
+
+    /// Creates the methods that will then be called in handleEvent to generate
+    /// the dictionaries from the Event's values
+    void Controller_Trampoline::initEventDict(
+                std::vector<std::function<py::object(Event*)> >& eventDict)
+    {
+        /// kind of ugly -> not choice but to instantiate a dummy typed event
+        /// to get the event's uid
+        Event* e = new AnimateBeginEvent(.0);
+        eventDict[e->getEventTypeIndex()] = [] (Event* event) -> py::object {
+            AnimateBeginEvent* evt = dynamic_cast<AnimateBeginEvent*>(event);
+            return py::dict("type"_a=evt->getClassName(),
+                            "isHandled"_a=evt->isHandled(),
+                            "dt"_a=evt->getDt());
+        };
+        e = new AnimateEndEvent(.0);
+        eventDict[e->getEventTypeIndex()] = [] (Event* event) -> py::object {
+            AnimateEndEvent* evt = dynamic_cast<AnimateEndEvent*>(event);
+            return py::dict("type"_a=evt->getClassName(),
+                            "isHandled"_a=evt->isHandled(),
+                            "dt"_a=evt->getDt());
+        };
+
+        e = new KeypressedEvent('\0');
+        eventDict[e->getEventTypeIndex()] = [] (Event* event) -> py::object {
+            KeypressedEvent* evt = dynamic_cast<KeypressedEvent*>(event);
+            return py::dict("type"_a=evt->getClassName(),
+                            "isHandled"_a=evt->isHandled(),
+                            "key"_a=evt->getKey());
+        };
+        e = new KeyreleasedEvent('\0');
+        eventDict[e->getEventTypeIndex()] = [] (Event* event) -> py::object {
+            KeyreleasedEvent* evt = dynamic_cast<KeyreleasedEvent*>(event);
+            return py::dict("type"_a=evt->getClassName(),
+                            "isHandled"_a=evt->isHandled(),
+                            "key"_a=evt->getKey());
+        };
+
+        e = new MouseEvent(MouseEvent::State::Move);
+        eventDict[e->getEventTypeIndex()] = [] (Event* event) -> py::object {
+            MouseEvent* evt = dynamic_cast<MouseEvent*>(event);
+
+            return py::dict("type"_a=evt->getClassName(),
+                            "isHandled"_a=evt->isHandled(),
+                            "State"_a=int(evt->getState()),
+                            "mouseX"_a=evt->getPosX(),
+                            "mouseY"_a=evt->getPosY(),
+                            "wheelDelta"_a=evt->getWheelDelta());
+        };
+
+        e = new ScriptEvent(nullptr, "");
+        eventDict[e->getEventTypeIndex()] = [] (Event* event) -> py::object {
+            ScriptEvent* evt = dynamic_cast<ScriptEvent*>(event);
+            return py::dict("type"_a=evt->getClassName(),
+                            "isHandled"_a=evt->isHandled(),
+                            "sender"_a=py::cast(evt->getSender()),
+                            "event_name"_a=evt->getEventName());
+        };
+
+        // TODO: bind other events' attributes here
+    }
+
+    /// If a method named "methodName" exists in the python controller,
+    /// methodName is called, with the Event's dict as argument
+    void Controller_Trampoline::callScriptMethod(
+                const py::object& self, Event* event, std::string methodName)
+    {
+        if( py::hasattr(self, methodName.c_str()) )
+        {
+            py::object fct = self.attr(methodName.c_str());
+
+            if (s_getEventDict.at(event->getEventTypeIndex()) != nullptr)
+                fct(s_getEventDict[event->getEventTypeIndex()](event));
+            else
+                fct(py::dict("type"_a=event->getClassName(),
+                             "isHandled"_a=event->isHandled()));
+        }
+    }
+
     void Controller_Trampoline::handleEvent(Event* event)
     {
+        if (!s_isDictCreated)
+        {
+            s_getEventDict.resize(sofa::core::objectmodel::Event::getEventTypeCount() + 1, nullptr);
+            initEventDict(s_getEventDict);
+            s_isDictCreated = true;
+        }
+
         py::object self = py::cast(this);
         std::string name = std::string("on")+event->getClassName();
 
@@ -63,7 +187,9 @@ namespace sofapython3
             try {
                 /// I didn't find any introspection tool in pybind11 to check
                 /// if an attr is a callable or not. Using try/catch instead
-                py::object ret = fct(name);
+                ///
+                /// Call the matching event in the funcVector & pass it the given event
+                callScriptMethod(self, event, name);
                 return;
             } catch (std::exception& /*e*/) {
                 /// fct is not a method. call the 'onEvent' fallback method instead
@@ -71,11 +197,7 @@ namespace sofapython3
         }
 
         /// Is the fallback method available.
-        if( py::hasattr(self, "onEvent") )
-        {
-            py::object fct = self.attr("onEvent");
-            py::object ret = fct(name);
-        }
+        callScriptMethod(self, event, "onEvent");
     }
 
     void moduleAddController(py::module &m) {

--- a/bindings/Sofa/tests/Core/Controller.py
+++ b/bindings/Sofa/tests/Core/Controller.py
@@ -25,11 +25,12 @@ class MyController(Sofa.Controller):
                 print(" Python::init() at "+str(self))
                 self.inited += 1
 
-        def onEvent(self, event):
-                print(" Handling event " + str(event))
+        def onEvent(self, kwargs):
+                print(" Handling event " + str(kwargs))
 
-        def onAnimateBeginEvent(self, other):
-                print(" Python::onAnimationBeginEvent() ("+str(other) + ")")
+        def onAnimateBeginEvent(self, kwargs):
+                print(" Python::onAnimationBeginEvent() ("+str(kwargs) + ")")
+                print(kwargs["dt"])
                 self.iterations+=1
 
 


### PR DESCRIPTION
Each event stores a std::function in a vector, that converts the specific args of the given Event into a py::dict, passed to the python Controller's event method.

Thus a single lambda is to be implemented to bind a new Event type to SofaPython3, and non-bound events are still usable, both through the generic onEvent method and through a specific python method, prefixed with "on".
Examples:

```py
def onEvent(self, dict): ## given the un-bound type UpdateMappingEndEvent
    print (dict) # will print: "{'type': 'UpdateMappingEndEvent', 'isHandled': False}"  <- only generic params

def onEvent(self, dict): ## given the bound type MouseEvent
    print (dict) # will print: "{'type': 'AnimateEndEvent', 'isHandled': False, 'state': 0, 'mouseX': 150, 'mouseY': 249, 'wheelDelta': 5}" <- event-specific values in the dict

def onAnimateBeginEvent(self, dict): # With an event-specific method
    print (dict) # will print: "{'type': 'AnimateBeginEvent', 'isHandled': False, 'dt': 0.01}" <- event-specific values in the dict

def onIntegrateBeginEvent(self, dict): # With an event-specific method hooked on an unbound type
    print (dict) # will print: "{'type': 'IntegrateBeginEvent', 'isHandled': False}" <- only generic params


```