### PR TITLE
[Bindings] Add bindings to some sofa::helper::vector data types.

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.h
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Submodule_Helper.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Binding_Vector.h
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.h
 )
@@ -48,6 +49,7 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Binding_Vector.cpp
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Vector.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Vector.cpp
@@ -1,0 +1,52 @@
+#include "Binding_Vector.h"
+
+#include <sofa/helper/vector.h>
+#include <sofa/core/objectmodel/BaseData.h>
+
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+
+namespace py { using namespace pybind11; }
+
+
+/**
+ * To add sofa::helper::vector types, follow the 2 steps below
+ */
+
+// ------------------------------------
+// STEP 1: Make the std vector type opaque
+// ------------------------------------
+PYBIND11_MAKE_OPAQUE(std::vector<int>);
+PYBIND11_MAKE_OPAQUE(std::vector<long>);
+PYBIND11_MAKE_OPAQUE(std::vector<unsigned int>);
+PYBIND11_MAKE_OPAQUE(std::vector<unsigned long>);
+PYBIND11_MAKE_OPAQUE(std::vector<float>);
+PYBIND11_MAKE_OPAQUE(std::vector<double>);
+PYBIND11_MAKE_OPAQUE(std::vector<sofa::core::objectmodel::BaseData*>);
+
+template<typename T>
+void declareVector(py::module &m, const std::string &typestr) {
+    std::string std_pyclass_name = std::string("StdVector") + typestr;
+    auto v = py::bind_vector<std::vector<T>>(m, std_pyclass_name);
+
+    std::string pyclass_name = std::string("Vector") + typestr;
+
+    py::class_<sofa::helper::vector<T>> (m, pyclass_name.c_str(), v);
+}
+
+namespace sofapython3 {
+
+void moduleAddVector(py::module &m) {
+// ------------------------------------
+// STEP 2: Declare the vector type to python
+// ------------------------------------
+    declareVector<int>(m, "int");
+    declareVector<long>(m, "long");
+    declareVector<unsigned int>(m, "uint");
+    declareVector<unsigned long>(m, "ulong");
+    declareVector<float>(m, "float");
+    declareVector<double>(m, "double");
+    declareVector<sofa::core::objectmodel::BaseData*>(m, "BaseData");
+}
+
+} /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Vector.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Vector.h
@@ -1,0 +1,17 @@
+#ifndef SOFAPYTHON3_SOFA_HELPER_BINDING_VECTOR_H
+#define SOFAPYTHON3_SOFA_HELPER_BINDING_VECTOR_H
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3
+{
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+    namespace py { using namespace pybind11; }
+
+    void moduleAddVector(py::module &m);
+
+} ///sofapython3
+
+
+#endif //SOFAPYTHON3_SOFA_HELPER_BINDING_VECTOR_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -2,6 +2,7 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <SofaPython3/PythonEnvironment.h>
 #include "Submodule_Helper.h"
+#include "Binding_Vector.h"
 
 namespace sofapython3
 {
@@ -117,6 +118,8 @@ pybind11::module addSubmoduleHelper(py::module& p)
     helper.def("msg_error", [](py::args args) { MESSAGE_DISPATCH(msg_error); });
     helper.def("msg_deprecated", [](py::args args) { MESSAGE_DISPATCH(msg_deprecated); });
     helper.def("msg_fatal", [](py::args args) { MESSAGE_DISPATCH(msg_fatal); });
+
+    moduleAddVector(helper);
 
     return helper;
 }


### PR DESCRIPTION
This PR adds the bindings of `sofa::helper::vector<T>`. The types `T` here need to be explicitly defined for every types unfortunately. I only added some of them to get it started. Since `sofa::helper::vector<T>` inherits from `std::vector<T>`, the bindings are pretty straightforwards with pybind11.

Of course, the types `T` must be wrapped in python.

This bindings can be used for instance when a function returns a helper::vector of some sort.

Example:

Base object has a method `getDataFields()` that returns a helper::vector<BaseData*>.

```
topo = node.addObject('HexahedronSetTopologyContainer')
for data in topo.getDataFields():  # returns a helper::vector<BaseData*>
    print (data.getName())

```