### PR TITLE
FIX out-of-tree builds of test binaries

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -87,6 +87,7 @@ SP3_add_python_module(
         ${PACKAGE_DIRECTORY}
 )
 
+
 if(SP3_BUILD_TEST)
     add_subdirectory(tests)
 endif()

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -4,14 +4,15 @@ project(PythonModule_Sofa_test)
 ####################################################################################################
 ### Module dependencies
 ####################################################################################################
-find_package(SofaPython3 QUIET)
-if(NOT SofaPython3_FOUND)
+if (NOT TARGET SofaPython3)
+  find_package(SofaPython3 QUIET)
+  if(NOT SofaPython3_FOUND)
     message("-- PythonModule_Sofa_test is disabled because 'SofaPython3' is missing or not activated.")
     return()
+  endif()
 endif()
 
 message("-- PythonModule_Sofa_test is enabled.")
-
 
 ####################################################################################################
 ### Building
@@ -37,6 +38,8 @@ set(PYTHON_FILES
     benchmark.py
     dataaccess.py
     )
+
+find_package(SofaGTestMain REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
 target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa)

--- a/bindings/SofaRuntime/tests/CMakeLists.txt
+++ b/bindings/SofaRuntime/tests/CMakeLists.txt
@@ -1,21 +1,25 @@
 cmake_minimum_required(VERSION 3.1)
-project(PythonSofaGeometry_test)
+project(PythonModule_SofaRuntime_test)
 
 ####################################################################################################
 ### Module dependencies
 ####################################################################################################
-find_package(SofaPython QUIET)
-if(NOT SofaPython_FOUND)
-    message("-- PythonSofaGeometry_test is disabled because 'SofaPython' is missing or not activated.")
+if (NOT TARGET SofaPython3)
+  find_package(SofaPython3 QUIET)
+  if(NOT SofaPython3_FOUND)
+    message("-- PythonModule_SofaRuntime_test is disabled because 'SofaPython3' is missing or not activated.")
     return()
+  endif()
 endif()
+
+message("-- PythonModule_SofaRuntime_test is enabled.")
+
 find_package(SofaTest QUIET)
 if(NOT SofaTest_FOUND)
-    message("-- PythonSofaGeometry_test is disabled because 'SofaTest' is missing or not activated.")
+    message("-- PythonModule_SofaRuntime_test is disabled because 'SofaTest' is missing or not activated.")
     return()
 endif()
 
-message("-- PythonSofaEditor_test is enabled.")
 
 
 ####################################################################################################
@@ -30,6 +34,8 @@ set(PYTHON_FILES
     pyfiles/Ray_test.py
     pyfiles/vector_test.py
     )
+
+find_package(SofaGTestMain REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
 target_link_libraries(${PROJECT_NAME} SofaTest SofaGTestMain)

--- a/bindings/SofaTypes/tests/CMakeLists.txt
+++ b/bindings/SofaTypes/tests/CMakeLists.txt
@@ -26,6 +26,8 @@ set(PYTHON_FILES
     pyfiles/vector_test.py
     )
 
+find_package(SofaGTestMain REQUIRED)
+
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
 target_link_libraries(${PROJECT_NAME} SofaPython3 SofaGTestMain)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/pyfiles/\"")


### PR DESCRIPTION
This should enable compilation of tests in out-of-tree builds.
Build was blocked by an incorrect inclusion of SofaPython3 target &  a missing find_package(SofaGTestMain) 