### PR TITLE
FIX: pythonDownCast now working for Nodes too

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -225,7 +225,7 @@ void moduleAddNode(py::module &m) {
     PythonDownCast::registerType<sofa::simulation::graph::DAGNode>(
                 [](sofa::core::objectmodel::Base* object)
     {
-        return py::cast(object->toBaseNode());
+        return py::cast(static_cast<Node*>(object->toBaseNode()));
     });
 
     py::class_<Node, sofa::core::objectmodel::BaseNode,


### PR DESCRIPTION
registration of nodes in the downcast factory was returning py::cast(BaseNode*) instead of py::cast(Node*), causing bindings to not properly work on objects captured that way from c++ to python.

This PR fixes the 2 broken tests in Node.py