### PR TITLE
FIX: missing SofaOpenGLVisual's required plugin

### DIFF
--- a/bindings/Sofa/tests/Core/ForceField.py
+++ b/bindings/Sofa/tests/Core/ForceField.py
@@ -50,8 +50,9 @@ def RestShapeObject(impl, name="unnamed", position=[]):
 class Test(unittest.TestCase):
     def test_animation(self):
         node = Sofa.Node("TestAnimation")
-        node.addObject("OglLineAxis")
+        node.addObject("RequiredPlugin", name="SofaOpenglVisual")
         node.addObject("RequiredPlugin", name="SofaSparseSolver")
+        node.addObject("OglLineAxis")
         node.addObject("DefaultAnimationLoop", name="loop")
         node.addObject("EulerImplicit")
         node.addObject("CGLinearSolver", tolerance=1e-12, threshold=1e-12)

--- a/bindings/Sofa/tests/Core/PythonRestShapeForceField.py
+++ b/bindings/Sofa/tests/Core/PythonRestShapeForceField.py
@@ -37,8 +37,9 @@ def RestShapeObject(impl, name="unnamed", position=[]):
         return node
  
 def createScene(node):
-        node.addObject("OglLineAxis")
         node.addObject("RequiredPlugin", name="SofaSparseSolver")
+        node.addObject("RequiredPlugin", name="SofaOpenglVisual")
+        node.addObject("OglLineAxis")
         node.addObject("DefaultAnimationLoop", name="loop")
         node.addObject("EulerImplicit")
         node.addObject("CGLinearSolver", tolerance=1e-12, threshold=1e-12)


### PR DESCRIPTION
This PR fixes the tests failures introduced by the pluginization of SofaOpenGLVisual, in ForceField.py