### PR TITLE
FIX: Compilation under clang (after passage to c++17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,11 @@ endif(SP3_BUILD_TEST)
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${EXTRA_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_SOFAPYTHON3")
 
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    # Sized deallocaion is not enabled by default under clang after c++14
+    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fsized-deallocation")
+endif ()
+
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationCore SofaSimulationGraph SofaComponentGeneral)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)


### PR DESCRIPTION
According to the release notes of Clang:
`The sized deallocation feature of C++14 is now controlled by the -fsized-deallocation flag. This feature relies on library support that isn’t yet widely deployed, so the user must supply an extra flag to get the extra functionality.`

Without the flag, clang spits out compile errors in pybind11 when trying to substitute `operator delete(p)` with `operator delete(p, s, std::align_val_t(a))`
( l.1008 in pybind11/pybind11.h )

