### PR TITLE
Replace with pragma

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_BASE_H
-#define PYTHONMODULE_SOFA_BINDING_BASE_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
@@ -77,5 +76,3 @@ void moduleAddBase(py::module& m);
 bool isProtectedKeyword(const std::string& name);
 
 } /// namespace sofapython3
-
-#endif /// PYTHONMODULE_SOFA_BINDING_BASE_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseController.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseController.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_BaseController_H
-#define PYTHONMODULE_SOFA_BINDING_BaseController_H
+#pragma once
 
 #include "Binding_BaseObject.h"
 
@@ -18,4 +17,3 @@ void moduleAddBaseController(py::module &m);
 
 } /// namespace sofapython3
 
-#endif /// PYTHONMODULE_SOFA_BINDING_BaseController_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.h
@@ -1,6 +1,4 @@
-
-#ifndef PYTHONMODULE_SOFA_BINDING_BASEDATA_H
-#define PYTHONMODULE_SOFA_BINDING_BASEDATA_H
+#pragma once
 
 #include <sofa/core/objectmodel/BaseData.h>
 #include "DataHelper.h"
@@ -15,5 +13,3 @@ namespace sofapython3
 {
     void moduleAddBaseData(py::module& m);
 } /// sofapython3
-
-#endif /// PYTHONMODULE_SOFA_BINDING_BASEDATA_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_CONTROLLER_H
-#define PYTHONMODULE_SOFA_BINDING_CONTROLLER_H
+#pragma once
 
 #include "Binding_BaseObject.h"
 
@@ -34,4 +33,3 @@ void moduleAddController(py::module &m);
 
 } /// namespace sofapython3
 
-#endif /// PYTHONMODULE_SOFA_BINDING_CONTROLLER_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataContainer.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataContainer.h
@@ -1,6 +1,4 @@
-
-#ifndef PYTHONMODULE_SOFA_BINDING_DATACONTAINER_H
-#define PYTHONMODULE_SOFA_BINDING_DATACONTAINER_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 #include <sofa/core/objectmodel/BaseData.h>
@@ -56,5 +54,3 @@ public:
 };
 
 }
-
-#endif /// PYTHONMODULE_SOFA_BINDING_DATACONTAINER_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_FORCEFIELD_H
-#define PYTHONMODULE_SOFA_BINDING_FORCEFIELD_H
+#pragma once
 
 #include "Binding_BaseObject.h"
 
@@ -21,5 +20,3 @@ using sofa::core::MultiVecDerivId;
 void moduleAddForceField(py::module &m);
 
 } /// namespace sofapython3
-
-#endif /// PYTHONMODULE_SOFA_BINDING_PYTHONCONTROLLER_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -219,8 +219,6 @@ py::object getItem(Node& self, std::list<std::string>& path)
 }
 
 void moduleAddNode(py::module &m) {
-    /// comprendre comment sont rajouté les méthodes dans le binding:
-    /// pybind11 => p.def()
     //py::options options;
     //options.disable_function_signatures();
 
@@ -249,9 +247,7 @@ void moduleAddNode(py::module &m) {
     /// Method: addObjects
     /// Only addObject is needed now, the createObject is deprecated and will prints
     /// a warning for old scenes.
-    p.def("addObject", &Node_addObject);
-
-    ////=> à regarder les lambda dans c++11
+    p.def("addObject", &Node_addObject, "Hello add object ...");
     p.def("addObject", [](Node& self, BaseObject* object) -> py::object
     {
         if(self.addObject(object))
@@ -305,13 +301,13 @@ void moduleAddNode(py::module &m) {
 
         n.removeChild(node);
         return py::cast(node);
-    }, "Remove a child Node");
+    });
 
     p.def("getRoot", &Node::getRoot);
     p.def("getPathName", &Node::getPathName);
     p.def("getLink", [](Node* node) {
         return ("@"+node->getPathName()).c_str();
-    }, "Returns a pointer to the link");
+    });
 
     p.def_property_readonly("children", [](Node* node)
     {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -219,6 +219,8 @@ py::object getItem(Node& self, std::list<std::string>& path)
 }
 
 void moduleAddNode(py::module &m) {
+    /// comprendre comment sont rajouté les méthodes dans le binding:
+    /// pybind11 => p.def()
     //py::options options;
     //options.disable_function_signatures();
 
@@ -247,7 +249,9 @@ void moduleAddNode(py::module &m) {
     /// Method: addObjects
     /// Only addObject is needed now, the createObject is deprecated and will prints
     /// a warning for old scenes.
-    p.def("addObject", &Node_addObject, "Hello add object...");
+    p.def("addObject", &Node_addObject);
+
+    ////=> à regarder les lambda dans c++11
     p.def("addObject", [](Node& self, BaseObject* object) -> py::object
     {
         if(self.addObject(object))
@@ -301,13 +305,13 @@ void moduleAddNode(py::module &m) {
 
         n.removeChild(node);
         return py::cast(node);
-    });
+    }, "Remove a child Node");
 
     p.def("getRoot", &Node::getRoot);
     p.def("getPathName", &Node::getPathName);
     p.def("getLink", [](Node* node) {
         return ("@"+node->getPathName()).c_str();
-    });
+    }, "Returns a pointer to the link");
 
     p.def_property_readonly("children", [](Node* node)
     {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_NODE_H
-#define PYTHONMODULE_SOFA_BINDING_NODE_H
+#pragma once
 #include <functional>
 #include <pybind11/pybind11.h>
 #include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
@@ -54,5 +53,3 @@ public:
 void moduleAddNode(py::module &m);
 
 } /// namespace sofapython3
-
-#endif /// PYTHONMODULE_SOFA_BINDING_NODE_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Simulation.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Simulation.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_SIMULATION_H
-#define PYTHONMODULE_SOFA_BINDING_SIMULATION_H
+#pragma once
 
 #include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
 
@@ -16,4 +15,3 @@ void moduleAddSimulation(py::module &m);
 
 } ///sofapython3
 
-#endif /// PYTHONMODULE_SOFA_BINDING_SIMULATION_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/DataCache.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/DataCache.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_CORE_DATACACHE_H
-#define SOFAPYTHON3_SOFA_CORE_DATACACHE_H
+#pragma once
 
 #include <pybind11/numpy.h>
 
@@ -31,8 +30,4 @@ py::array getPythonArrayFor(BaseData* d);
 void trimCache();
 
 } /// sofapython3
-
-
-#endif /// SOFAPYTHON3_SOFA_CORE_DATACACHE_H
-
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/DataHelper.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/DataHelper.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_CORE_DATAHELPER_H
-#define SOFAPYTHON3_SOFA_CORE_DATAHELPER_H
+#pragma once
 
 #include <iostream>
 #include <pybind11/pybind11.h>
@@ -146,8 +145,5 @@ private:
 };
 
 }  // namespace sofapython3
-
-
-#endif /// SOFAPYTHON3_SOFA_CORE_DATAHELPER_H
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_CORE_SUBMODULE_H
-#define SOFAPYTHON3_SOFA_CORE_SUBMODULE_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -10,7 +9,5 @@ namespace py { using namespace pybind11; }
 py::module addSubmoduleCore(py::module& m) ;
 
 } /// namespace sofapython3
-
-#endif /// SOFAPYTHON3_SOFA_CORE_SUBMODULE_H
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Vector.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Binding_Vector.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_HELPER_BINDING_VECTOR_H
-#define SOFAPYTHON3_SOFA_HELPER_BINDING_VECTOR_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -12,6 +11,3 @@ namespace sofapython3
     void moduleAddVector(py::module &m);
 
 } ///sofapython3
-
-
-#endif //SOFAPYTHON3_SOFA_HELPER_BINDING_VECTOR_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.h
@@ -1,6 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_HELPER_SUBMODULE_H
-#define SOFAPYTHON3_SOFA_HELPER_SUBMODULE_H
-
+#pragma once
 #include <pybind11/pybind11.h>
 
 namespace sofapython3
@@ -10,7 +8,5 @@ namespace py { using namespace pybind11; }
 py::module addSubmoduleHelper(py::module& m) ;
 
 } /// namespace sofapython3
-
-#endif /// SOFAPYTHON3_SOFA_HELPER_SUBMODULE_H
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_SIMULATION_SUBMODULE_H
-#define SOFAPYTHON3_SOFA_SIMULATION_SUBMODULE_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -10,5 +9,3 @@ namespace py { using namespace pybind11; }
 pybind11::module addSubmoduleSimulation(py::module& m) ;
 
 } ///namespace sofapython3
-
-#endif /// SOFAPYTHON3_SOFA_SIMULATION_SUBMODULE_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_BOUNDINGBOX_H
-#define PYTHONMODULE_SOFA_BINDING_BOUNDINGBOX_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -13,6 +12,3 @@ namespace py { using namespace pybind11; }
 void moduleAddBoundingBox(py::module& m);
 
 }  // namespace sofapython3
-
-
-#endif  // PYTHONMODULE_SOFA_BINDING_BOUNDINGBOX_H

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Submodule_Types.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Submodule_Types.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_TYPES_SUBMODULE_H
-#define SOFAPYTHON3_SOFA_TYPES_SUBMODULE_H
+#pragma once
 
 
 #include <pybind11/pybind11.h>
@@ -11,6 +10,3 @@ namespace py { using namespace pybind11; }
 py::module addSubmoduleTypes(py::module& m) ;
 
 } /// namespace sofapython3
-
-
-#endif // SOFAPYTHON3_SOFA_TYPES_SUBMODULE_H

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.h
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_SOFA_TIMER_SUBMODULE_H
-#define SOFAPYTHON3_SOFA_TIMER_SUBMODULE_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 
@@ -11,4 +10,3 @@ pybind11::module addSubmoduleTimer(py::module& m) ;
 
 } ///namespace sofapython3
 
-#endif /// SOFAPYTHON3_SOFA_TIMER_SUBMODULE_H

--- a/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Mat.h
+++ b/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Mat.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_MAT_H
-#define PYTHONMODULE_SOFA_BINDING_MAT_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
@@ -16,5 +15,3 @@ std::string __str__(const Mat<R, C, double> &self, bool repr = false);
 } // namespace pyMat
 
 void moduleAddMat(py::module& m);
-
-#endif  // PYTHONMODULE_SOFA_BINDING_MAT_H

--- a/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Quat.h
+++ b/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Quat.h
@@ -1,5 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_QUAT_H
-#define PYTHONMODULE_SOFA_BINDING_QUAT_H
+#pragma once
 
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
@@ -10,5 +9,3 @@ using namespace pybind11::literals;
 using sofa::defaulttype::Quat;
 
 void moduleAddQuat(py::module& m);
-
-#endif  // PYTHONMODULE_SOFA_BINDING_QUAT_H

--- a/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Vec.h
+++ b/bindings/SofaTypes/src/SofaPython3/SofaTypes/Binding_Vec.h
@@ -1,6 +1,4 @@
-#ifndef PYTHONMODULE_SOFA_BINDING_VEC_H
-#define PYTHONMODULE_SOFA_BINDING_VEC_H
-
+#pragma once
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -14,5 +12,3 @@ std::string __str__(const Vec<N, T> &self, bool repr = false);
 } // namespace pyVec
 
 void moduleAddVec(py::module &m);
-
-#endif // PYTHONMODULE_SOFA_BINDING_VEC_H

--- a/src/SofaPython3/PythonEnvironment.h
+++ b/src/SofaPython3/PythonEnvironment.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFAPYTHON3_PYTHONENVIRONMENT_H
-#define SOFAPYTHON3_PYTHONENVIRONMENT_H
+#pragma once
 
 #include <vector>
 #include <string>
@@ -128,4 +127,3 @@ private:
 
 } // namespace sofapython3
 
-#endif // PYTHONENVIRONMENT_H

--- a/src/SofaPython3/PythonTest.h
+++ b/src/SofaPython3/PythonTest.h
@@ -1,5 +1,4 @@
-#ifndef SOFAPYTHON3_PYTHONTEST_H
-#define SOFAPYTHON3_PYTHONTEST_H
+#pragma once
 
 #include <string>
 #include "config.h"
@@ -75,5 +74,3 @@ public:
 };
 
 }
-
-#endif /// PYTHONTEST_H_

--- a/src/SofaPython3/SceneLoaderPY3.h
+++ b/src/SofaPython3/SceneLoaderPY3.h
@@ -19,8 +19,7 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFAPYTHON3_SCENELOADERPY3_H
-#define SOFAPYTHON3_SCENELOADERPY3_H
+#pragma once
 
 #include <string>
 #include <map>
@@ -63,5 +62,3 @@ public:
 };
 
 } // namespace sofapython3
-
-#endif // SOFAPYTHON3_SCENELOADERPY3_H

--- a/src/SofaPython3/config.h
+++ b/src/SofaPython3/config.h
@@ -19,11 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFAPYTHON3_CONFIG_H
-#define SOFAPYTHON3_CONFIG_H
+#pragma once
 
 #include <SofaGeneral/config.h>
 
 #define SOFAPYTHON3_API
-
-#endif /// SOFAPYTHON3_CONFIG_H

--- a/src/SofaPython3/initModule.h
+++ b/src/SofaPython3/initModule.h
@@ -19,10 +19,8 @@
 *                                                                             *
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
-#ifndef SOFAPYTHON3_INIT_H
-#define SOFAPYTHON3_INIT_H
+#pragma once
 
 #include <SofaPython3/config.h>
 
-#endif /// SOFAPYTHON3_INIT_H
 


### PR DESCRIPTION
The ifndef directive is used to check if the identifier that follows it has been defined. In this case, it is used to check if the header has already been included previously in the code. That way, the header is included only once.

It is replaced here with pragma once, a non-standard but widely supported directive that does the same thing, more efficiently.