### PR TITLE
Expose binding factory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fsized-deallocation")
 endif ()
 
-target_link_libraries(${PROJECT_NAME} PRIVATE SofaCore SofaSimulationCore SofaSimulationGraph SofaComponentGeneral)
+target_link_libraries(${PROJECT_NAME} PRIVATE SofaCore SofaGeneral SofaSimulationCore SofaSimulationGraph SofaComponentGeneral)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # dlopen() is used on Linux for a workaround (see PythonEnvironnement.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,13 +75,21 @@ set(HEADER_FILES
     src/SofaPython3/initModule.h
     src/SofaPython3/PythonEnvironment.h
     src/SofaPython3/SceneLoaderPY3.h
+
+    src/SofaPython3/DataCache.h
+    src/SofaPython3/DataHelper.h
+    src/SofaPython3/PythonDownCast.h
 )
 
 set(SOURCE_FILES
     src/SofaPython3/initModule.cpp
     src/SofaPython3/PythonEnvironment.cpp
     src/SofaPython3/SceneLoaderPY3.cpp
-)
+
+    src/SofaPython3/DataCache.cpp
+    src/SofaPython3/DataHelper.cpp
+    src/SofaPython3/PythonDownCast.cpp
+    )
 
 set(EXTRA_FILES
     SofaPython3Config.cmake.in
@@ -98,14 +106,15 @@ if(SP3_BUILD_TEST)
 endif(SP3_BUILD_TEST)
     
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${EXTRA_FILES})
-set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-DSOFA_BUILD_SOFAPYTHON3")
+target_compile_definitions(${PROJECT_NAME} PRIVATE "-DSOFA_BUILD_SOFAPYTHON3")
+target_compile_definitions(${PROJECT_NAME} PUBLIC "-DSOFA_HAVE_SOFAPYTHON3")
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Sized deallocaion is not enabled by default under clang after c++14
     set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fsized-deallocation")
 endif ()
 
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaCore SofaSimulationCore SofaSimulationGraph SofaComponentGeneral)
+target_link_libraries(${PROJECT_NAME} PRIVATE SofaCore SofaSimulationCore SofaSimulationGraph SofaComponentGeneral)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # dlopen() is used on Linux for a workaround (see PythonEnvironnement.cpp)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -19,3 +19,8 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/installed-bindings-config"
 add_subdirectory(Sofa)
 add_subdirectory(SofaRuntime)
 add_subdirectory(SofaTypes)
+
+find_package(SofaExporter QUIET)
+if (SofaExporter_FOUND)
+  add_subdirectory(SofaExporter)
+endif (SofaExporter_FOUND)

--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -23,9 +23,6 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
 
 
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/DataCache.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/DataHelper.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/PythonDownCast.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.h
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Types/Submodule_Types.h
@@ -49,9 +46,6 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.cpp
 
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/DataCache.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/DataHelper.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/PythonDownCast.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
 
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Types/Submodule_Types.cpp
@@ -85,7 +79,7 @@ SP3_add_python_module(
         ${SOURCE_FILES}
         ${HEADER_FILES}
     DEPENDS
-        SofaCore SofaSimulationGraph SofaPython3 SofaBaseVisual 
+        SofaCore SofaSimulationCore SofaSimulationGraph SofaPython3 SofaBaseVisual
     DESTINATION
         ${PACKAGE_DIRECTORY}
 )

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -15,7 +15,7 @@ using sofa::core::objectmodel::BaseLink;
 #include <sofa/helper/accessor.h>
 using sofa::helper::WriteOnlyAccessor;
 
-#include "PythonDownCast.h"
+#include <SofaPython3/PythonDownCast.h>
 
 #include "Binding_Base.h"
 #include "Binding_Base_doc.h"

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseCamera.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseCamera.cpp
@@ -28,7 +28,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include "Binding_BaseObject.h"
 #include "Binding_BaseCamera.h"
 
-#include <SofaPython3/Sofa/Core/PythonDownCast.h>
+#include <SofaPython3/PythonDownCast.h>
 
 namespace sofapython3
 {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseController.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseController.cpp
@@ -3,7 +3,7 @@
 
 #include "Binding_Base.h"
 #include "Binding_BaseController.h"
-#include "DataHelper.h"
+#include <SofaPython3/DataHelper.h>
 
 #include <sofa/core/objectmodel/Event.h>
 using sofa::core::objectmodel::Event;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
@@ -16,7 +16,7 @@ using  sofa::core::objectmodel::BaseNode;
 #include "Binding_Base.h"
 #include "Binding_BaseData.h"
 #include "Binding_DataContainer.h"
-#include "DataHelper.h"
+#include <SofaPython3/DataHelper.h>
 
 namespace sofapython3
 {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.h
@@ -3,13 +3,16 @@
 #define PYTHONMODULE_SOFA_BINDING_BASEDATA_H
 
 #include <sofa/core/objectmodel/BaseData.h>
-#include "DataHelper.h"
+#include <SofaPython3/DataHelper.h>
 
 /// More info about smart pointer in
 /// pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
 /// BaseData are raw ptr so we use the raw_ptr smart pointer.
 /// If you have a better way to do that, please make a PR.
 PYBIND11_DECLARE_HOLDER_TYPE(BaseData, sofapython3::raw_ptr<BaseData>)
+
+template class pybind11::class_<sofa::core::objectmodel::BaseData, sofapython3::raw_ptr<sofa::core::objectmodel::BaseData>>;
+
 
 namespace sofapython3
 {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.cpp
@@ -1,7 +1,7 @@
 #include "Binding_BaseObject.h"
 #include "Binding_Controller.h"
 
-#include "PythonDownCast.h"
+#include <SofaPython3/PythonDownCast.h>
 
 namespace sofapython3
 {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.h
@@ -5,7 +5,6 @@
 #include <sofa/core/objectmodel/BaseObject.h>
 
 #include "Binding_Base.h"
-#include "Binding_BaseObject.h"
 
 template class pybind11::class_<sofa::core::objectmodel::BaseObject,
                                 sofa::core::objectmodel::Base,

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -3,7 +3,7 @@
 
 #include "Binding_Base.h"
 #include "Binding_Controller.h"
-#include "DataHelper.h"
+#include <SofaPython3/DataHelper.h>
 
 #include <sofa/core/objectmodel/Event.h>
 using sofa::core::objectmodel::Event;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataContainer.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataContainer.cpp
@@ -11,7 +11,7 @@ using  sofa::core::objectmodel::BaseObject;
 #include <sofa/core/objectmodel/BaseNode.h>
 using  sofa::core::objectmodel::BaseNode;
 
-#include "DataHelper.h"
+#include <SofaPython3/DataHelper.h>
 #include "Binding_Base.h"
 #include "Binding_BaseData.h"
 #include "Binding_DataContainer.h"
@@ -274,6 +274,10 @@ void moduleAddDataContainer(py::module& m)
 
         return py::reinterpret_steal<py::object>(PyNumber_Multiply(p.ptr(), value.ptr()));
     });
+
+    getBindingDataFactoryInstance()->registerCreator(
+                "DataContainer", new TypeCreator<DataContainer*>());
+
 }
 
 void moduleAddWriteAccessor(py::module& m)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataContainer.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataContainer.h
@@ -11,33 +11,6 @@ namespace sofapython3
 namespace py { using namespace pybind11; }
 using sofa::core::objectmodel::BaseData;
 
-class scoped_write_access
-{
-public:
-    BaseData* data{nullptr};
-    void* ptr{nullptr};
-    scoped_write_access(BaseData* data_) : data(data_){ ptr = data->beginEditVoidPtr(); }
-    ~scoped_write_access(){ data->endEditVoidPtr(); }
-};
-
-class scoped_read_access
-{
-public:
-    BaseData* data{nullptr};
-    void* ptr{nullptr};
-    scoped_read_access(BaseData* data_) : data(data_){ ptr = data->beginEditVoidPtr(); }
-    ~scoped_read_access(){ data->endEditVoidPtr(); }
-};
-
-class scoped_writeonly_access
-{
-public:
-    BaseData* data {nullptr};
-    void* ptr{nullptr};
-    scoped_writeonly_access(BaseData* data_) : data(data_){ ptr = data->beginEditVoidPtr(); }
-    ~scoped_writeonly_access(){ data->endEditVoidPtr(); }
-};
-
 void moduleAddDataContainer(py::module& m);
 void moduleAddDataAsString(py::module& m);
 void moduleAddWriteAccessor(py::module& m);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
@@ -2,7 +2,7 @@
 #include <pybind11/detail/init.h>
 #include "Binding_BaseObject.h"
 #include "Binding_ForceField.h"
-#include "DataHelper.h"
+#include <SofaPython3/DataHelper.h>
 
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/behavior/ForceField.h>

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -17,13 +17,13 @@ using sofa::helper::logging::Message;
 using sofa::core::ExecParams;
 
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
-#include <SofaPython3/Sofa/Core/DataHelper.h>
+#include <SofaPython3/DataHelper.h>
 #include "Binding_Node.h"
 
 #include <sofa/core/ObjectFactory.h>
 using sofa::core::ObjectFactory;
 
-#include <SofaPython3/Sofa/Core/PythonDownCast.h>
+#include <SofaPython3/PythonDownCast.h>
 using sofapython3::PythonDownCast;
 
 using sofa::core::objectmodel::BaseObjectDescription;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/DataHelper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/DataHelper.cpp
@@ -299,8 +299,8 @@ py::object convertToPython(BaseData* d)
 
     std::cout << nfo.name() << " is not a container nor a scalar." << std::endl;
 
-    if (getBindingDataFactoryInstance()->createObject("BoundingBox", d))
-        return py::cast(getBindingDataFactoryInstance()->createObject("BoundingBox", d));
+    if (getBindingDataFactoryInstance()->createObject(nfo.name(), d))
+        return py::cast(getBindingDataFactoryInstance()->createObject(nfo.name(), d));
 
     std::cout << nfo.name() << " No such type in the BindingDataFactory. returning string" << std::endl;
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/DataHelper.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/DataHelper.h
@@ -104,6 +104,8 @@ py::slice toSlice(const py::object& o);
 std::string getPathTo(Base* b);
 const char* getFormat(const AbstractTypeInfo& nfo);
 
+std::map<void*, py::array>& getObjectCache();
+void trimCache();
 py::buffer_info toBufferInfo(BaseData& m);
 py::object convertToPython(BaseData* d);
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.cpp
@@ -1,6 +1,6 @@
 #include <sofa/core/objectmodel/Data.h>
 #include "Binding_BoundingBox.h"
-#include "SofaPython3/Sofa/Core/DataHelper.h"
+#include "SofaPython3/DataHelper.h"
 
 namespace sofapython3 {
 

--- a/bindings/SofaExporter/CMakeLists.txt
+++ b/bindings/SofaExporter/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.1)
+project(SofaPython3_SofaExporter)
+
+####################################################################################################
+### Module dependencies
+####################################################################################################
+if (NOT TARGET SofaPython3)
+    find_package(SofaPython3 REQUIRED)
+endif()
+if (NOT TARGET SofaPython3_Sofa)
+    find_package(SofaPython3_Sofa REQUIRED)
+endif()
+
+set(HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaExporter/Binding_STLExporter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaExporter/Binding_STLExporter_doc.h
+)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaExporter/Binding_STLExporter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaExporter/Module_SofaExporter.cpp
+)
+
+
+set(MODULE_NAME SofaExporter)
+set(PACKAGE_DIRECTORY  ${SP3_PYTHON_PACKAGES_DIRECTORY})
+
+SP3_add_python_package(
+        SOURCE_DIRECTORY
+            ${CMAKE_CURRENT_SOURCE_DIR}/package
+        TARGET_DIRECTORY
+            ${PACKAGE_DIRECTORY}
+)
+
+SP3_add_python_module(
+    TARGET
+        ${PROJECT_NAME}
+    MODULE_NAME
+        ${MODULE_NAME}
+    SOURCES
+        ${SOURCE_FILES}
+        ${HEADER_FILES}
+    DEPENDS
+        SofaCore SofaPython3 SofaPython3_Sofa SofaExporter
+    DESTINATION
+        ${PACKAGE_DIRECTORY}
+)
+
+if(SP3_BUILD_TEST)
+    add_subdirectory(tests)
+endif()

--- a/bindings/SofaExporter/src/SofaExporter/Binding_STLExporter.cpp
+++ b/bindings/SofaExporter/src/SofaExporter/Binding_STLExporter.cpp
@@ -1,0 +1,24 @@
+#include <SofaExporter/Binding_STLExporter.h>
+#include <SofaExporter/Binding_STLExporter_doc.h>
+
+#include <SofaPython3/PythonDownCast.h>
+
+using  sofa::component::exporter::STLExporter;
+
+namespace sofapython3
+{
+
+void moduleAddSTLExporter(py::module &m)
+{
+    PythonDownCast::registerType<STLExporter>(
+                [](sofa::core::objectmodel::Base* object)
+    {
+        return py::cast(dynamic_cast<STLExporter*>(object));
+    });
+
+    py::class_<STLExporter, sofa::core::objectmodel::BaseObject, sofa::core::sptr<STLExporter>> p(m, "STLExporter");
+
+    p.def("write", &STLExporter::write, sofapython3::doc::SofaExporter::STLExporter::write::docstring);
+}
+
+} // namespace sofapython3

--- a/bindings/SofaExporter/src/SofaExporter/Binding_STLExporter.h
+++ b/bindings/SofaExporter/src/SofaExporter/Binding_STLExporter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include <SofaExporter/STLExporter.h>
+#include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
+
+template class pybind11::class_<sofa::component::exporter::STLExporter,
+                                sofa::core::objectmodel::BaseObject,
+                                sofa::core::sptr<sofa::component::exporter::STLExporter>>;
+
+
+namespace sofapython3
+{
+
+void moduleAddSTLExporter(py::module &m);
+
+} /// namespace sofapython3

--- a/bindings/SofaExporter/src/SofaExporter/Binding_STLExporter_doc.h
+++ b/bindings/SofaExporter/src/SofaExporter/Binding_STLExporter_doc.h
@@ -22,35 +22,30 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 ********************************************************************/
 #pragma once
 
-#include <sofa/core/objectmodel/Base.h>
-#include <pybind11/pybind11.h>
-
-/////////////////////////////// DECLARATION //////////////////////////////
-namespace sofapython3
+namespace sofapython3::doc::SofaExporter::STLExporter::write
 {
-    /// Makes an alias for the pybind11 namespace to increase readability.
-    namespace py { using namespace pybind11; }
 
-    typedef std::function<py::object(sofa::core::objectmodel::Base*)> downCastingFunction;
+static auto docstring =
+        R"(
+        Exports a STL file
+        Will export a binary or ascii file depending on the binary flag of STLExporter
+        Will auto-number the exported files
+        ---------------
 
-    class PythonDownCast
-    {
-    public:
-        static py::object toPython(sofa::core::objectmodel::Base* object);
+        Example of use:
+          .. code-block:: python
 
-        template<class T>
-        static void registerType(downCastingFunction fct)
-        {
-            s_downcastingFct[T::GetClass()->className] = fct;
-        }
+             import Sofa
+             import SofaExporter
 
-        static std::map<std::string, downCastingFunction>::iterator searchLowestCastAvailable(const sofa::core::objectmodel::BaseClass* metaclass);
+             # Create a new node
+             n = Sofa.Core.Node("root"")
 
-    private:
-        static std::map<std::string, downCastingFunction> s_downcastingFct;
-    };
-} /// sofapython3
+             # Add STLExporter
+             n.addObject("STLExporter", name="exporter", ...)
 
+             # writes down the stl file
+             n.exporter.write()
 
-
-
+        )";
+}

--- a/bindings/SofaExporter/src/SofaExporter/Module_SofaExporter.cpp
+++ b/bindings/SofaExporter/src/SofaExporter/Module_SofaExporter.cpp
@@ -1,0 +1,35 @@
+#include <pybind11/eval.h>
+namespace py = pybind11;
+
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
+
+#include <SofaExporter/Binding_STLExporter.h>
+
+namespace sofapython3
+{
+
+PYBIND11_MODULE(SofaExporter, m) {
+    m.doc() = R"doc(
+              SofaRuntime
+              -----------------------
+
+              Provides python bindings for the SofaExporter module
+
+              Example of use:
+              .. code-block:: python
+
+              import SofaExporter
+
+              .. automethod::
+              :toctree: _autosummary
+
+              )doc";
+
+    py::module::import("Sofa");
+
+    moduleAddSTLExporter(m);
+}
+
+}  // namespace sofapython3
+

--- a/bindings/SofaExporter/tests/CMakeLists.txt
+++ b/bindings/SofaExporter/tests/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.1)
+project(PythonModule_SofaExporter_test)
+
+####################################################################################################
+### Module dependencies
+####################################################################################################
+if (NOT TARGET SofaPython3)
+  find_package(SofaPython3 QUIET)
+  if(NOT SofaPython3_FOUND)
+    message("-- PythonModule_Sofa_test is disabled because 'SofaPython3' is missing or not activated.")
+    return()
+  endif()
+endif()
+
+message("-- PythonModule_Sofa_test is enabled.")
+
+####################################################################################################
+### Building
+####################################################################################################
+set(SOURCE_FILES
+    PythonModule_SofaExporter_test.cpp
+)
+
+set(PYTHON_FILES
+    STLExporter.py
+    )
+
+find_package(SofaGTestMain REQUIRED)
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
+target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa SofaExporter)
+target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
@@ -36,6 +36,8 @@ using sofapython3::SceneLoaderPY3;
 #include "Timer/Submodule_Timer.h"
 #include "Input/Submodule_Input.h"
 
+#include <SofaPython3/DataHelper.h>
+
 namespace sofapython3
 {
 
@@ -68,22 +70,22 @@ PYBIND11_MODULE(SofaRuntime, m) {
               -----------------------
 
               Example of use:
-                .. code-block:: python
+              .. code-block:: python
 
-                   import SofaRuntime
-                    SofaRuntime.importPlugin("MechanicalObject"")
+              import SofaRuntime
+              SofaRuntime.importPlugin("MechanicalObject"")
 
-                .. automethod::
-                  :toctree: _autosummary
+              .. automethod::
+              :toctree: _autosummary
 
-                  SofaRuntime.importPlugin
-             )doc";
+              SofaRuntime.importPlugin
+              )doc";
 
     // Add the plugin directory to PluginRepository
     const std::string& pluginDir = Utils::getExecutableDirectory();
     PluginRepository.addFirstPath(pluginDir);
 
-    //if( !sofa::simulation::getSimulation() )
+    // if( !sofa::simulation::getSimulation() )
     //    sofa::simulation::setSimulation(new DAGSimulation());
 
     /// We need to import the project dependencies
@@ -106,4 +108,4 @@ PYBIND11_MODULE(SofaRuntime, m) {
     addSubmoduleTimer(m);
 }
 
-}
+}  // namespace sofapython3

--- a/src/SofaPython3/DataCache.cpp
+++ b/src/SofaPython3/DataCache.cpp
@@ -1,0 +1,1 @@
+#include "DataCache.h"

--- a/src/SofaPython3/DataCache.h
+++ b/src/SofaPython3/DataCache.h
@@ -26,8 +26,8 @@ using sofa::core::objectmodel::BaseData;
 bool hasArrayFor(BaseData* d);
 
 ///@brief
-py::array resetArrayFor(BaseData* d);
-py::array getPythonArrayFor(BaseData* d);
+py::array PYBIND11_EXPORT resetArrayFor(BaseData* d);
+py::array PYBIND11_EXPORT getPythonArrayFor(BaseData* d);
 void trimCache();
 
 } /// sofapython3

--- a/src/SofaPython3/DataHelper.cpp
+++ b/src/SofaPython3/DataHelper.cpp
@@ -3,9 +3,8 @@
 #include <sofa/core/objectmodel/BaseData.h>
 #include <sofa/defaulttype/DataTypeInfo.h>
 
-#include <SofaPython3/Sofa/Core/Binding_DataContainer.h>
-#include <SofaPython3/Sofa/Core/DataHelper.h>
-#include <SofaPython3/Sofa/Core/DataCache.h>
+#include <SofaPython3/DataHelper.h>
+#include <SofaPython3/DataCache.h>
 
 namespace sofapython3
 {
@@ -359,7 +358,7 @@ py::object toPython(BaseData* d, bool writeable)
         if(!writeable)
         {
             getPythonArrayFor(d);
-            return py::cast(reinterpret_cast<DataContainer*>(d));
+            return py::cast(getBindingDataFactoryInstance()->createObject("DataContainer", d));
         }
         return getPythonArrayFor(d);
     }

--- a/src/SofaPython3/DataHelper.h
+++ b/src/SofaPython3/DataHelper.h
@@ -73,13 +73,13 @@ public:
 
 BindingDataFactory* getBindingDataFactoryInstance();
 
-class PythonTrampoline
+class PYBIND11_EXPORT PythonTrampoline
 {
 protected:
     std::shared_ptr<PyObject> pyobject;
 public:
     virtual ~PythonTrampoline();
-    virtual void setInstance(py::object s);
+    virtual void PYBIND11_EXPORT setInstance(py::object s);
 };
 
 template <typename T> class py_shared_ptr : public sofa::core::sptr<T>
@@ -94,27 +94,27 @@ public:
     }
 };
 
-void setItem2D(py::array a, py::slice slice, py::object o);
-void setItem2D(py::array a, const py::slice& slice,
+void PYBIND11_EXPORT setItem2D(py::array a, py::slice slice, py::object o);
+void PYBIND11_EXPORT setItem2D(py::array a, const py::slice& slice,
                const py::slice& slice1, py::object o);
-void setItem1D(py::array a, py::slice slice, py::object o);
-void setItem(py::array a, py::slice slice, py::object value);
+void PYBIND11_EXPORT setItem1D(py::array a, py::slice slice, py::object o);
+void PYBIND11_EXPORT setItem(py::array a, py::slice slice, py::object value);
 
-py::slice toSlice(const py::object& o);
+py::slice PYBIND11_EXPORT toSlice(const py::object& o);
 std::string getPathTo(Base* b);
 const char* getFormat(const AbstractTypeInfo& nfo);
 
 std::map<void*, py::array>& getObjectCache();
 void trimCache();
-py::buffer_info toBufferInfo(BaseData& m);
-py::object convertToPython(BaseData* d);
+py::buffer_info PYBIND11_EXPORT toBufferInfo(BaseData& m);
+py::object PYBIND11_EXPORT convertToPython(BaseData* d);
 
-py::object toPython(BaseData* d, bool writeable=false);
-void copyFromListScalar(BaseData& d, const AbstractTypeInfo& nfo, const py::list& l);
-void fromPython(BaseData* d, const py::object& o);
+py::object PYBIND11_EXPORT toPython(BaseData* d, bool writeable=false);
+void PYBIND11_EXPORT copyFromListScalar(BaseData& d, const AbstractTypeInfo& nfo, const py::list& l);
+void PYBIND11_EXPORT fromPython(BaseData* d, const py::object& o);
 
 template<typename T>
-void copyScalar(BaseData* a, const AbstractTypeInfo& nfo, py::array_t<T, py::array::c_style> src)
+void PYBIND11_EXPORT copyScalar(BaseData* a, const AbstractTypeInfo& nfo, py::array_t<T, py::array::c_style> src)
 {
     void* ptr = a->beginEditVoidPtr();
 
@@ -145,6 +145,34 @@ public:
     T& operator[](std::size_t idx) const { return ptr[idx]; }
 private:
     T* ptr;
+};
+
+
+class scoped_write_access
+{
+public:
+    BaseData* data{nullptr};
+    void* ptr{nullptr};
+    scoped_write_access(BaseData* data_) : data(data_){ ptr = data->beginEditVoidPtr(); }
+    ~scoped_write_access(){ data->endEditVoidPtr(); }
+};
+
+class scoped_read_access
+{
+public:
+    BaseData* data{nullptr};
+    void* ptr{nullptr};
+    scoped_read_access(BaseData* data_) : data(data_){ ptr = data->beginEditVoidPtr(); }
+    ~scoped_read_access(){ data->endEditVoidPtr(); }
+};
+
+class scoped_writeonly_access
+{
+public:
+    BaseData* data {nullptr};
+    void* ptr{nullptr};
+    scoped_writeonly_access(BaseData* data_) : data(data_){ ptr = data->beginEditVoidPtr(); }
+    ~scoped_writeonly_access(){ data->endEditVoidPtr(); }
 };
 
 }  // namespace sofapython3

--- a/src/SofaPython3/PythonDownCast.cpp
+++ b/src/SofaPython3/PythonDownCast.cpp
@@ -22,7 +22,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 ********************************************************************/
 
 #include <functional>
-#include <SofaPython3/Sofa/Core/PythonDownCast.h>
+#include "PythonDownCast.h"
 #include <SofaSimulationGraph/DAGNode.h>
 
 namespace sofapython3

--- a/src/SofaPython3/PythonDownCast.h
+++ b/src/SofaPython3/PythonDownCast.h
@@ -1,0 +1,55 @@
+/*********************************************************************
+Copyright 2019, Inria, CNRS, University of Lille
+
+This file is part of runSofa2
+
+runSofa2 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+runSofa2 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+********************************************************************/
+#pragma once
+
+#include <sofa/core/objectmodel/Base.h>
+#include <pybind11/pybind11.h>
+
+/////////////////////////////// DECLARATION //////////////////////////////
+namespace sofapython3
+{
+    /// Makes an alias for the pybind11 namespace to increase readability.
+    namespace py { using namespace pybind11; }
+
+    typedef std::function<py::object(sofa::core::objectmodel::Base*)> downCastingFunction;
+
+    class PythonDownCast
+    {
+        static std::map<std::string, downCastingFunction> PYBIND11_EXPORT s_downcastingFct;
+    public:
+        static py::object PYBIND11_EXPORT toPython(sofa::core::objectmodel::Base* object);
+
+        template<class T>
+        static void registerType(downCastingFunction fct)
+        {
+            PythonDownCast::s_downcastingFct[T::GetClass()->className] = fct;
+        }
+
+        static std::map<std::string, downCastingFunction>::iterator searchLowestCastAvailable(const sofa::core::objectmodel::BaseClass* metaclass);
+
+    };
+} /// sofapython3
+
+
+
+


### PR DESCRIPTION
This PR:
- moves DataHelper / DataCache / Downcasting in the SofaPython3 library (instead of SofaPython3_Sofa)
- Refactors the BindingDataFactory to  expose it to external modules (bindings in plugins or in additional modules in SofaPython3
- Adds a SofaExporter module with the STLExporter::write() binding method as an example of external module binding.
- Rescopes the target_link_libraries to private whenever possible

**What I learned about pybind11 in this PR:**

**1.** In order to bind a class that inherits another bound class, it's necessary to have access to the prototype of the base class, but also to the whole inheritance tree's classes.
Thus a good coding practice is to add, in the Binding_XXX.h, an `extern template class_` of the binding usually defined in Binding_XXX.cpp, and to include the parent's binding's header. For instance, Binding_BaseObject.h will contain the following declaration:

```cpp
template class pybind11::class_<sofa::core::objectmodel::BaseObject,
                                sofa::core::objectmodel::Base,
                                sofa::core::sptr<sofa::core::objectmodel::BaseObject>>;
```

and will also include `Binding_Base.h`, to provide access to the template class def of Binding_Base.

Further down in the bindings, A BaseCamera component for instance will declare its own `template class ....`, and include `BInding_BaseObject.h` which in turn includes `Binding_Base.h` so the cascade inclusion of the template class defs is OK.

**2.** There's an annoying trick I had to figure out when building libs that declare prototypes of functions containing pybind11 symbols in their signatures: The trick is, that by default, the visibility of pybind11 symbols is set to hidden. Thus a code loading a shared library exposing functions & classes with pybind11 stuff in its signature will simply not be able to see the hidden symbols.
This leads to link errors (undefined reference in the case of GCC, and a slightly more elaborate message for clang, saying that the symbols are hidden and thus can't be linked against.)
In order to fix this, you need to add PYBIND11_EXPORT (which translates into this: `#    define PYBIND11_EXPORT __attribute__ ((visibility("default")))`) in order to expose the symbols in your dll.
