### PR TITLE
REFACTOR: Sofa modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fsized-deallocation")
 endif ()
 
-target_link_libraries(${PROJECT_NAME} PRIVATE SofaCore SofaGeneral SofaSimulationCore SofaSimulationGraph SofaComponentGeneral)
+target_link_libraries(${PROJECT_NAME} PRIVATE SofaCore SofaSimulationCore SofaSimulationGraph SofaComponentGeneral)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # dlopen() is used on Linux for a workaround (see PythonEnvironnement.cpp)

--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT TARGET SofaPython3)
     find_package(SofaPython3 REQUIRED)
 endif()
 
-set(HEADER_FILES
+set(CORE_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Base.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseData.h
@@ -21,20 +21,24 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
-
-
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.h
+    )
 
+set(TYPES_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Types/Submodule_Types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Types/Binding_BoundingBox.h
+    )
 
+set(HELPER_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Submodule_Helper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Binding_Vector.h
+    )
 
+set(SIMULATION_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.h
-)
+    )
 
-set(SOURCE_FILES
+set(CORE_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Base.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseObject.cpp
@@ -45,43 +49,88 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.cpp
-
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+    )
 
+set(TYPES_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Types/Submodule_Types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Types/Binding_BoundingBox.cpp
+    )
 
+set(HELPER_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Binding_Vector.cpp
+    )
 
+set(SIMULATION_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Module_Sofa.cpp
-)
+    )
 
 
-set(MODULE_NAME Sofa)
+set(MODULE_NAMES "Core, Simulation, Helper, Types")
 set(PACKAGE_DIRECTORY  ${SP3_PYTHON_PACKAGES_DIRECTORY})
 
 SP3_add_python_package(
         SOURCE_DIRECTORY
             ${CMAKE_CURRENT_SOURCE_DIR}/package
         TARGET_DIRECTORY
-            ${PACKAGE_DIRECTORY}
+            ${PACKAGE_DIRECTORY}/Sofa
 )
 
 SP3_add_python_module(
     TARGET
-        ${PROJECT_NAME}
+        ${PROJECT_NAME}_Core
     MODULE_NAME
-        ${MODULE_NAME}
+        Core
     SOURCES
-        ${SOURCE_FILES}
-        ${HEADER_FILES}
+        ${CORE_SOURCE_FILES}
+        ${CORE_HEADER_FILES}
     DEPENDS
         SofaCore SofaSimulationCore SofaSimulationGraph SofaPython3 SofaBaseVisual
     DESTINATION
-        ${PACKAGE_DIRECTORY}
+        ${PACKAGE_DIRECTORY}/Sofa
+)
+
+SP3_add_python_module(
+    TARGET
+        ${PROJECT_NAME}_Helper
+    MODULE_NAME
+        Helper
+    SOURCES
+        ${HELPER_SOURCE_FILES}
+        ${HELPER_HEADER_FILES}
+    DEPENDS
+        SofaCore SofaSimulationCore SofaSimulationGraph SofaPython3 SofaBaseVisual
+    DESTINATION
+        ${PACKAGE_DIRECTORY}/Sofa
+)
+
+SP3_add_python_module(
+    TARGET
+        ${PROJECT_NAME}_Simulation
+    MODULE_NAME
+        Simulation
+    SOURCES
+        ${SIMULATION_SOURCE_FILES}
+        ${SIMULATION_HEADER_FILES}
+    DEPENDS
+        SofaCore SofaSimulationCore SofaSimulationGraph SofaPython3 SofaBaseVisual
+    DESTINATION
+        ${PACKAGE_DIRECTORY}/Sofa
+)
+
+SP3_add_python_module(
+    TARGET
+        ${PROJECT_NAME}_Types
+    MODULE_NAME
+        Types
+    SOURCES
+        ${TYPES_SOURCE_FILES}
+        ${TYPES_HEADER_FILES}
+    DEPENDS
+        SofaCore SofaSimulationCore SofaSimulationGraph SofaPython3 SofaBaseVisual
+    DESTINATION
+        ${PACKAGE_DIRECTORY}/Sofa
 )
 
 

--- a/bindings/Sofa/package/__init__.py
+++ b/bindings/Sofa/package/__init__.py
@@ -22,16 +22,6 @@ Submodules:
     Sofa.Simulation
     Sofa.Types
     Sofa.Helper
-
-Functions:
-  .. autosummary::
-
-    Sofa.msg_info
-    Sofa.msg_warning
-    Sofa.msg_error
-    Sofa.msg_fatal
-    Sofa.msg_deprecated
-
 """
 
-from .@MODULE_NAME@  import *
+from . import @MODULE_NAMES@

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -22,10 +22,8 @@ namespace sofapython3
 {
 
 /// The first parameter must be named the same as the module file to load.
-pybind11::module addSubmoduleCore(py::module& p)
-{   
-    py::module core = p.def_submodule("Core");
-
+PYBIND11_MODULE(Core, core)
+{
     core.doc() = R"doc(
            Scene components
            -----------------------
@@ -84,9 +82,6 @@ pybind11::module addSubmoduleCore(py::module& p)
             sofa::core::objectmodel::Context::SPtr>(core, "Context");
 
     moduleAddNode(core);
-    //moduleAddSimulation(core);
-
-    return core;
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -80,10 +80,8 @@ static void parse_emitter_message_then(py::args args, const Action& action) {
 }
 
 /// The first parameter must be named the same as the module file to load.
-pybind11::module addSubmoduleHelper(py::module& p)
-{   
-    py::module helper = p.def_submodule("Helper");
-
+PYBIND11_MODULE(Helper, helper)
+{
     helper.doc() = R"doc(
            Utility functions
            -----------------------
@@ -121,8 +119,6 @@ pybind11::module addSubmoduleHelper(py::module& p)
     helper.def("msg_fatal", [](py::args args) { MESSAGE_DISPATCH(msg_fatal); });
 
     moduleAddVector(helper);
-
-    return helper;
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Module_Sofa.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Module_Sofa.cpp
@@ -7,37 +7,21 @@ namespace sofapython3
 {
 
 /// The first parameter must be named the same as the module file to load.
-PYBIND11_MODULE(Sofa, m)
+PYBIND11_MODULE(Core, c)
 {
-    m.doc() = R"doc(
-              Sofa
-              -----------------------
-
-              Example of use:
-                .. code-block:: python
-
-                   import Sofa
-
-                   n = Sofa.Core.Node("MyNode"")
-                   n.addChild("Node2")
-                   n.addObject("MechanicalObject", name="dofs")
-
-                   Sofa.Simulation.init(root)
-                   Sofa.Simulation.print(root)
-
-              Submodules:
-                .. autosummary::
-                  :toctree: _autosummary
-
-                  Sofa.Core
-                  Sofa.Simulation
-                  Sofa.Types
-                  Sofa.Helper
-             )doc";
-    py::module core = addSubmoduleCore(m);
-    py::module helper = addSubmoduleHelper(m);
-    py::module simulation = addSubmoduleSimulation(m);
-    py::module types = addSubmoduleTypes(m);
+    addSubmoduleCore(c);
+}
+PYBIND11_MODULE(Helper, h)
+{
+    addSubmoduleHelper(h);
+}
+PYBIND11_MODULE(Simulation, s)
+{
+    addSubmoduleSimulation(s);
+}
+PYBIND11_MODULE(Types, t)
+{
+    addSubmoduleTypes(t);
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.cpp
@@ -9,12 +9,8 @@ using sofa::simulation::graph::DAGSimulation;
 using sofa::simulation::Node;
 using namespace pybind11::literals;
 
-#include <SofaPython3/Sofa/Core/Binding_BaseObject.h>
-
 #include <sofa/simulation/Simulation.h>
 using sofa::simulation::Simulation;
-
-template class pybind11::class_<Simulation, Simulation::SPtr>;
 
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/visual/DrawToolGL.h>
@@ -22,12 +18,10 @@ template class pybind11::class_<Simulation, Simulation::SPtr>;
 namespace sofapython3
 {
 
-py::module addSubmoduleSimulation(py::module &m)
+PYBIND11_MODULE(Simulation, simulation)
 {
     if(!sofa::simulation::getSimulation())
         sofa::simulation::setSimulation(new DAGSimulation());
-
-    py::module simulation = m.def_submodule("Simulation");
 
     simulation.doc() = R"doc(
            Simulation
@@ -79,9 +73,6 @@ py::module addSubmoduleSimulation(py::module &m)
     {
         glewInit();
     });
-
-
-    return simulation;
 }
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Submodule_Types.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Submodule_Types.cpp
@@ -4,10 +4,8 @@
 namespace sofapython3
 {
 /// The first parameter must be named the same as the module file to load.
-py::module addSubmoduleTypes(py::module& p)
+PYBIND11_MODULE(Types, types)
 {
-    py::module types = p.def_submodule("Types");
-
     types.doc() = R"doc(
            Default types available in Sofa
            -----------------------
@@ -20,8 +18,6 @@ py::module addSubmoduleTypes(py::module& p)
        )doc";
 
     moduleAddBoundingBox(types);
-
-    return types;
 }
 
 }  // namespace sofapython3

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(PYTHON_FILES
     Helper/Message.py
     Types/RGBAColor.py
     Types/Vec3.py
+    Types/BoundingBox.py
     Simulation/Node.py
     bench_datacontainer.py
     bench_node.py
@@ -42,7 +43,7 @@ set(PYTHON_FILES
 find_package(SofaGTestMain REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa)
+target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa_Types SofaPython3_Sofa_Simulation SofaPython3_Sofa_Helper SofaPython3_Sofa_Core)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/bindings/Sofa/tests/Core/AutoDiffForceField.py
+++ b/bindings/Sofa/tests/Core/AutoDiffForceField.py
@@ -49,7 +49,7 @@ class MyForceField(Sofa.Core.ForceField):
         df += tdf.reshape((-1,3))
         
     def addKToMatrix(self, a, b):
-        print(" NOT IMPLEMENTED a,b are non" )
+        print(" NOT IMPLEMENTED a, b are none" )
 
 class CreateObject(object):
         def __init__(self, *args, **kwargs):

--- a/bindings/Sofa/tests/Core/BaseData.py
+++ b/bindings/Sofa/tests/Core/BaseData.py
@@ -45,7 +45,6 @@ class Test(unittest.TestCase):
                 v=numpy.array([[0,0,0],[1,1,1],[2,2,2],[3,3,3]])
                 c = root.addObject("MechanicalObject", name="t", position=v.tolist())
                 c.position.value *= 2.0
-
                 numpy.testing.assert_array_equal(c.position.array(), v*2.0)
                 c.position.value += 3.0
                 numpy.testing.assert_array_equal(c.position.array(), (v*2.0)+3.0)
@@ -124,6 +123,7 @@ class Test(unittest.TestCase):
                 root = Sofa.Core.Node("rootNode")
                 v=numpy.array([[0,0,0],[1,1,1],[2,2,2],[3,3,3]])
                 c = root.addObject("MechanicalObject", name="t", position=v.tolist())
+                print(dir(c.position.value))
                 c2 = c.position.value * 2.0
 
                 numpy.testing.assert_array_equal(c.position.array(), v)

--- a/bindings/Sofa/tests/Helper/Message.py
+++ b/bindings/Sofa/tests/Helper/Message.py
@@ -12,7 +12,7 @@ class Test(unittest.TestCase):
             f("Emitter", "Simple message")
             f("Simple message with attached source info", "sourcefile.py", 10)
             f(Sofa.Core.Node("node"), "Simple message to an object")
-            f(Sofa..Core.Node("node"), "Simple message to an object with attached source info", "sourcefile.py", 10)
+            f(Sofa.Core.Node("node"), "Simple message to an object with attached source info", "sourcefile.py", 10)
 
             
 def runTests():

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -27,7 +27,7 @@ class Test(unittest.TestCase):
                 c = root.createChild("child1")
                 c.createObject("MechanicalObject", position=[0.0,1.0,2.0]*100)
                 root.init()
-                self.assertTrue( c.position.size() = 100*3)
+                self.assertTrue(c.position.size() == 100*3)
 
         def test_createObjectInvalid(self):
                 root = Sofa.Core.Node("rootNode")

--- a/bindings/Sofa/tests/Types/BoundingBox.py
+++ b/bindings/Sofa/tests/Types/BoundingBox.py
@@ -1,0 +1,26 @@
+# coding: utf8
+
+import unittest
+import Sofa
+
+
+class Test(unittest.TestCase):
+    def test_constructor(self):
+        Sofa.Helper.msg_error("No ctor in this class yet")
+
+    def test_getMin(self):
+        Sofa.Helper.msg_error("Not implemented yet")
+
+    def test_getMax(self):
+        Sofa.Helper.msg_error("Not implemented yet")
+
+    def test_setMin(self):
+        Sofa.Helper.msg_error("Not implemented yet")
+
+    def test_setMax(self):
+        Sofa.Helper.msg_error("Not implemented yet")
+
+
+def runTests():
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test)
+    return unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()

--- a/bindings/SofaExporter/CMakeLists.txt
+++ b/bindings/SofaExporter/CMakeLists.txt
@@ -7,8 +7,8 @@ project(SofaPython3_SofaExporter)
 if (NOT TARGET SofaPython3)
     find_package(SofaPython3 REQUIRED)
 endif()
-if (NOT TARGET SofaPython3_Sofa)
-    find_package(SofaPython3_Sofa REQUIRED)
+if (NOT TARGET SofaPython3_Sofa_Core)
+    find_package(SofaPython3_Sofa_Core REQUIRED)
 endif()
 
 set(HEADER_FILES
@@ -41,7 +41,7 @@ SP3_add_python_module(
         ${SOURCE_FILES}
         ${HEADER_FILES}
     DEPENDS
-        SofaCore SofaPython3 SofaPython3_Sofa SofaExporter
+        SofaCore SofaPython3 SofaPython3_Sofa_Core SofaExporter
     DESTINATION
         ${PACKAGE_DIRECTORY}
 )

--- a/bindings/SofaExporter/tests/CMakeLists.txt
+++ b/bindings/SofaExporter/tests/CMakeLists.txt
@@ -22,13 +22,13 @@ set(SOURCE_FILES
 )
 
 set(PYTHON_FILES
-    STLExporter.py
+    tests/STLExporter.py
     )
 
 find_package(SofaGTestMain REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa SofaExporter)
+target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa_Core SofaExporter)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/bindings/SofaExporter/tests/PythonModule_SofaExporter_test.cpp
+++ b/bindings/SofaExporter/tests/PythonModule_SofaExporter_test.cpp
@@ -1,0 +1,70 @@
+/******************************************************************************
+*       SOFA, Simulation Open-Framework Architecture, development version     *
+*                (c) 2006-2018 INRIA, USTL, UJF, CNRS, MGH                    *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+/******************************************************************************
+ * Contributors:                                                              *
+ *    - damien.marchal@univ-lille1.fr                                         *
+ *****************************************************************************/
+
+#include <vector>
+
+#include <SofaPython3/PythonTest.h>
+using sofapython3::PythonTest ;
+using sofapython3::PythonTestList ;
+using sofapython3::PrintTo ;
+using std::string;
+
+#include <sofa/core/logging/PerComponentLoggingMessageHandler.h>
+using sofa::helper::logging::MessageDispatcher;
+using sofa::helper::logging::MainPerComponentLoggingMessageHandler;
+
+namespace
+{
+
+bool init()
+{
+    MessageDispatcher::addHandler(&MainPerComponentLoggingMessageHandler::getInstance()) ;
+    return true;
+}
+
+static int _inited_=init();
+
+class SofaExporter : public PythonTest {};
+
+/// static build of the test list
+static struct PythonModule_SofaExporter_tests : public PythonTestList
+{
+    PythonModule_SofaExporter_tests()
+    {
+        addTestDir(std::string(PYTHON_TESTFILES_DIR)+"/tests", "SofaExporter_");
+    }
+} python_tests;
+
+/// run test list using the custom name function getTestName.
+/// this allows to do gtest_filter=*FileName*
+INSTANTIATE_TEST_CASE_P(SofaPython3,
+                        SofaExporter,
+                        ::testing::ValuesIn(python_tests.list),
+                        SofaExporter::getTestName);
+
+TEST_P(SofaExporter, all_tests) { run(GetParam()); }
+
+}

--- a/bindings/SofaExporter/tests/tests/STLExporter.py
+++ b/bindings/SofaExporter/tests/tests/STLExporter.py
@@ -1,0 +1,30 @@
+# coding: utf8
+
+import Sofa
+import unittest
+import numpy
+
+class Test(unittest.TestCase):
+    def test_STLExporter(self):
+        import SofaExporter
+        Sofa.Helper.msg_error("Not implemented yet")
+
+
+def getTestsName():
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test)
+    return [test.id().split(".")[2] for test in suite]
+
+
+def runTests():
+    import sys
+    suite = None
+    if(len(sys.argv) == 1):
+        suite = unittest.TestLoader().loadTestsFromTestCase(Test)
+    else:
+        suite = unittest.TestSuite()
+        suite.addTest(Test(sys.argv[1]))
+    return unittest.TextTestRunner(verbosity=1).run(suite).wasSuccessful()
+
+
+def createScene(rootNode):
+    runTests()

--- a/bindings/SofaRuntime/CMakeLists.txt
+++ b/bindings/SofaRuntime/CMakeLists.txt
@@ -42,7 +42,7 @@ SP3_add_python_module(
         ${SOURCE_FILES}
         ${HEADER_FILES}
     DEPENDS
-        SofaCore SofaSimulationGraph SofaPython3 SofaPython3_Sofa
+        SofaCore SofaSimulationGraph SofaPython3 SofaPython3_Sofa_Core
     DESTINATION
         ${PACKAGE_DIRECTORY}
 )

--- a/bindings/SofaRuntime/tests/CMakeLists.txt
+++ b/bindings/SofaRuntime/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ set(PYTHON_FILES
 find_package(SofaGTestMain REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
-target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa)
+target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa_Core)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/src/SofaPython3/DataHelper.h
+++ b/src/SofaPython3/DataHelper.h
@@ -42,9 +42,9 @@ public:
     virtual DataType createInstance(
             sofa::core::objectmodel::BaseData* data) override
     {
-        return dynamic_cast<DataType>(data);
+        return reinterpret_cast<DataType>(data);
     }
-    virtual const std::type_info& type() override { return typeid(sofa::Data<DataType>);}
+    virtual const std::type_info& type() override { return typeid(DataType);}
 };
 
 class BindingDataFactory : public sofa::helper::Factory< std::string, sofa::core::objectmodel::BaseData*, sofa::core::objectmodel::BaseData*, sofa::core::objectmodel::BaseData*>
@@ -58,6 +58,7 @@ public:
         while (it != end)
         {
             creator = (*it).second;
+            std::cout << creator->type().name() << std::endl;
             object = creator->createInstance(arg);
             if (object != nullptr)
             {

--- a/src/SofaPython3/config.h
+++ b/src/SofaPython3/config.h
@@ -21,6 +21,6 @@
 ******************************************************************************/
 #pragma once
 
-#include <SofaGeneral/config.h>
+#include <sofa/config.h>
 
 #define SOFAPYTHON3_API


### PR DESCRIPTION
This PR fixes the matching between stubs & import for the Sofa module:

site-packages now looks like this:

```
$> tree .                                                                                                                                                                             .
├── Sofa
│   ├── __init__.py  //> from . import Core, Helper, Simulation, Types
│   ├── Core.cpython-36m-x86_64-linux-gnu.so
│   ├── Helper.cpython-36m-x86_64-linux-gnu.so
│   ├── Simulation.cpython-36m-x86_64-linux-gnu.so
│   └── Types.cpython-36m-x86_64-linux-gnu.so
├── SofaCV.cpython-36m-x86_64-linux-gnu.so
├── SofaExporter.cpython-36m-x86_64-linux-gnu.so
├── SofaRuntime.cpython-36m-x86_64-linux-gnu.so
└── SofaTypes.cpython-36m-x86_64-linux-gnu.so

```