### PR TITLE
Add docstring documentation for binded BaseObject, Base and Node.

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseData.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseObject.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseObject_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseCamera.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_DataContainer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseController.h

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -512,7 +512,7 @@ void checkAmbiguousCreation(py::object& py_self, const std::string& name, const 
 
 void moduleAddBase(py::module &m)
 {
-    py::class_<Base, Base::SPtr> base(m, "Base", py::dynamic_attr(), doc::Base::Class);
+    py::class_<Base, Base::SPtr> base(m, "Base", py::dynamic_attr(), doc::base::BaseClass);
 
     base.def("getName", &Base::getName,
              pybind11::return_value_policy::copy,
@@ -521,13 +521,13 @@ void moduleAddBase(py::module &m)
     base.def("setName", pybind11::overload_cast<const std::string&, int>(&Base::setName), sofapython3::doc::base::setNameCounter);
     base.def("getClass", &Base::getClass, pybind11::return_value_policy::reference, sofapython3::doc::base::getClass);
     base.def("getDefinitionSourceFilePos", &Base::getDefinitionSourceFilePos,
-             sofapython3::doc::Base::getDefinitionSourceFilePos);
+             sofapython3::doc::base::getDefinitionSourceFilePos);
     base.def("getDefinitionSourceFileName", &Base::getDefinitionSourceFileName,
-             sofapython3::doc::Base::getDefinitionSourceFileName);
+             sofapython3::doc::base::getDefinitionSourceFileName);
     base.def("getInstanciationSourceFilePos", &Base::getInstanciationSourceFilePos,
-             sofapython3::doc::Base::getInstanciationSourceFilePos);
+             sofapython3::doc::base::getInstanciationSourceFilePos);
     base.def("getInstanciationFileName", &Base::getInstanciationSourceFileName,
-             sofapython3::doc::Base::getInstanciationSourceFilePos);
+             sofapython3::doc::base::getInstanciationSourceFilePos);
     base.def("findData", &Base::findData, pybind11::return_value_policy::reference, sofapython3::doc::base::findData);
     base.def("getDataFields", &Base::getDataFields, pybind11::return_value_policy::reference, sofapython3::doc::base::getDataFields);
     base.def("findLink", &Base::findLink, pybind11::return_value_policy::reference, sofapython3::doc::base::findLink);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -316,11 +316,7 @@ void moduleAddDataDict(py::module& m)
     /// DataDict binding
     ////////////////////////////////////////////////////////////////////////////////////////////////
     py::class_<DataDict> d(m, "DataDict",
-                           R"(DataDict exposes the data of a sofa object in a way similar to a normal python dictionnary.
-                           Eg:
-                           for k,v in anObject.__data__.items():
-                           print("Data name :"+k+" value:" +str(v)))
-                           )");
+                           sofapython3::doc::dataDict::Class);
     d.def("__len__", [](DataDict& self)
     {
         return self.owner->getDataFields().size();
@@ -370,15 +366,15 @@ void moduleAddDataDict(py::module& m)
     d.def("keys", [](DataDict& d)
     {
         return DataDictIterator(d.owner, true, false);
-    });
+    }, sofapython3::doc::dataDict::keys);
     d.def("values", [](DataDict& d)
     {
         return DataDictIterator(d.owner, false, true);
-    });
+    }, sofapython3::doc::dataDict::values);
     d.def("items", [](DataDict& d)
     {
         return DataDictIterator(d.owner, true, true);
-    });
+    }, sofapython3::doc::dataDict::items);
 }
 
 
@@ -520,17 +516,17 @@ void moduleAddBase(py::module &m)
 
     base.def("getName", &Base::getName,
              pybind11::return_value_policy::copy,
-             doc::base::getName);
-    base.def("setName", pybind11::overload_cast<const std::string&>(&Base::setName));
-    base.def("setName", pybind11::overload_cast<const std::string&, int>(&Base::setName));
-    base.def("getClass", &Base::getClass, pybind11::return_value_policy::reference);
+             doc::base::getName, sofapython3::doc::base::getName);
+    base.def("setName", pybind11::overload_cast<const std::string&>(&Base::setName), sofapython3::doc::base::setName);
+    base.def("setName", pybind11::overload_cast<const std::string&, int>(&Base::setName), sofapython3::doc::base::setNameCounter);
+    base.def("getClass", &Base::getClass, pybind11::return_value_policy::reference, sofapython3::doc::base::getClass);
 
     //base.def("getSourceFileName", &Base::getSourceFileName);
     //base.def("getSourceFileLoc", &Base::getSourceFileLoc);
-    base.def("findData", &Base::findData, pybind11::return_value_policy::reference);
-    base.def("getDataFields", &Base::getDataFields, pybind11::return_value_policy::reference);
-    base.def("findLink", &Base::findLink, pybind11::return_value_policy::reference);
-    base.def("getLinks", &Base::getLinks, pybind11::return_value_policy::reference);
+    base.def("findData", &Base::findData, pybind11::return_value_policy::reference, sofapython3::doc::base::findData);
+    base.def("getDataFields", &Base::getDataFields, pybind11::return_value_policy::reference, sofapython3::doc::base::getDataFields);
+    base.def("findLink", &Base::findLink, pybind11::return_value_policy::reference, sofapython3::doc::base::findLink);
+    base.def("getLinks", &Base::getLinks, pybind11::return_value_policy::reference, sofapython3::doc::base::getLinks);
     base.def("addData", [](py::object py_self, const std::string& name,
              py::object value = py::object(), const std::string& help = "",
              const std::string& group = "", std::string type = "")
@@ -585,7 +581,7 @@ void moduleAddBase(py::module &m)
         data->setDisplayed(true);
         data->setPersistent(true);
 
-    }, "name"_a, "value"_a = "", "help"_a = "", "group"_a = "", "type"_a = "");
+    }, sofapython3::doc::base::addData);
 
     base.def("addData", [](Base* self, py::object d) {
         BaseData* data = py::cast<BaseData*>(d);
@@ -601,7 +597,7 @@ void moduleAddBase(py::module &m)
             newData->setParent(data);
             newData->setName(data->getName());
         }
-    });
+    }, sofapython3::doc::base::addDataInitialized);
 
     base.def("__dir__", [](Base* self)
     {
@@ -621,7 +617,7 @@ void moduleAddBase(py::module &m)
             return py::cast(d);
         }
         return py::none();
-    });
+    }, sofapython3::doc::base::getData);
 
 
     base.def("__getattr__", [](py::object self, const std::string& s) -> py::object

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.cpp
@@ -2,6 +2,7 @@
 #include "Binding_Controller.h"
 
 #include "PythonDownCast.h"
+#include "Binding_BaseObject_doc.h"
 
 namespace sofapython3
 {
@@ -27,12 +28,12 @@ void moduleAddBaseObject(py::module& m)
         return py::cast(object->toBaseObject());
     });
 
-    py::class_<BaseObject, Base, BaseObject::SPtr>p(m, "Object");
-    p.def("init", &BaseObject::init);
-    p.def("reinit", &BaseObject::init);
+    py::class_<BaseObject, Base, BaseObject::SPtr>p(m, "Object", sofapython3::doc::baseObject::Class);
+    p.def("init", &BaseObject::init, sofapython3::doc::baseObject::init);
+    p.def("reinit", &BaseObject::init, sofapython3::doc::baseObject::reinit);
 
-    p.def("getPathName", &BaseObject::getPathName);
-    p.def("getLink", [](const BaseObject &self){ return std::string("@") + self.getPathName(); });
+    p.def("getPathName", &BaseObject::getPathName, sofapython3::doc::baseObject::getPathName);
+    p.def("getLink", [](const BaseObject &self){ return std::string("@") + self.getPathName(); }, sofapython3::doc::baseObject::getLink);
 
     /// gets an item using its path (path is dot-separated, relative to the object
     /// it's called upon & ONLY DESCENDING (no ../):

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject_doc.h
@@ -1,0 +1,55 @@
+/*********************************************************************
+Copyright 2019, Inria, CNRS, University of Lille
+
+This file is part of runSofa2
+
+runSofa2 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+runSofa2 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::baseObject
+{
+static auto Class =
+        R"(
+        Base class for simulation components.
+
+        An object defines a part of the functionnality in the simulation
+        (stores state data, specify topology, compute forces, etc).
+        Each simulation object is related to a context, which gives access to all available external data.
+        It is able to process events, if listening enabled (default is false).
+        )";
+static auto init =
+        R"(
+        Initialization method called at graph creation and modification, during top-down traversal.Initialize data.
+        )";
+
+static auto reinit =
+        R"(
+        Update method called when variables used in precomputation are modified.
+        )";
+static auto getPathName =
+        R"(
+        Return the full path name of this baseObject
+        :rtype: string
+        )";
+
+static auto getLink =
+        R"(
+        Return the link of the baseObject
+        :param self: the baseObject itself
+        :type self: baseObject
+        :rtype: string
+        )";
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
@@ -22,7 +22,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 ********************************************************************/
 #pragma once
 
-namespace sofapython3::doc::Base
+namespace sofapython3::doc::base
 {
 static auto BaseClass =
         R"(

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
@@ -26,16 +26,132 @@ namespace sofapython3::doc::base
 {
 
 static auto BaseClass =
-        R"(Sofa.Core.Base is the root of the Sofa class Hierarhcy
-
+        R"(
+        Sofa.Core.Base is the root of the Sofa class Hierarhcy
         All objects are in-heriting from this one.
         )";
 
 static auto getName =
-        R"(Returns the name of the entity
-
-        :rtype str:
+        R"(
+        Return the name of the entity
+        :rtype: string
         )";
-static auto addObject = "Hello";
+static auto setName =
+        R"(
+        Set the name of this object
+        :param n
+        :type n: string
+        )";
 
+static auto setNameCounter =
+        R"(
+        Set the name of this object, adding an integer counter
+        :param n
+        :param counter
+        :type n: string
+        :type counter: integer
+        )";
+
+static auto getClass =
+        R"(
+        Return the class of the object
+        )";
+
+static auto findData =
+        R"(
+        Find a data field given its name.
+        Return NULL if not found.
+        If more than one field is found (due to aliases), only the first is returned.
+        :param name
+        :type name: string
+        :return: the data field
+        )";
+
+static auto getDataFields =
+        R"(
+        Accessor to the vector containing all the fields of this object
+        :return: A vector containing the data fields
+        )";
+
+static auto findLink =
+        R"(
+        Find a link given its name.
+        Return NULL if not found.
+        If more than one link is found (due to aliases), only the first is returned.
+        :param name: the name of the link
+        :type name: string
+        :return: the link
+        )";
+
+static auto getLinks =
+        R"(
+        Accessor to the vector containing all the links of this object
+        :return: A vector containing the links
+        )";
+
+static auto addData =
+        R"(
+        Create a data field, then adds it to the base.
+        Note that this method should only be called if the field was not initialized with the initData method
+        :param self: the base itself
+        :param name: the name of the data to be added
+        :param value: the value from which the data can be created
+        :param help: help message that describes the data to be created
+        :param group: the group the data belongs to
+        :param type: the type of the data
+        :type self: object
+        :type name: string
+        :type value: object
+        :type help: string
+        :type groupe: string
+        :type type: string
+        )";
+
+static auto addDataInitialized =
+        R"(
+        Add a data field.
+        Note that this method should only be called if the field was not initialized with the initData method
+        :param self: the base itself
+        :param d: the data to be added
+        :type self: Base*
+        :type d: object
+        )";
+
+
+static auto getData =
+        R"(
+        Get the data field given its name.
+        :param self:
+        :param s:
+        :type self: Base&
+        :type s: string
+        :return: the first data found of this name
+        )";
+}
+
+namespace sofapython3::doc::dataDict {
+
+static auto Class =
+        R"(
+        DataDict exposes the data of a sofa object in a way similar to a normal python dictionnary.
+        :Example:
+        for k,v in anObject.__data__.items():
+        print("Data name :"+k+" value:" +str(v)))
+        )";
+
+static auto keys =
+        R"(
+        Expose the data, but only the key (the name) of each items
+        )";
+static auto values =
+        R"(
+        Expose the data, but only the value of each items
+        )";
+static auto items =
+        R"(
+        Expose the data, both the key and the value of each item.
+        :Example:
+        for k,v in anObject.__data__.items():
+        print("Data name :"+k+" value:" +str(v)))
+        )";
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -232,28 +232,28 @@ void moduleAddNode(py::module &m) {
 
     py::class_<Node, sofa::core::objectmodel::BaseNode,
             sofa::core::objectmodel::Context, Node::SPtr>
-            p(m, "Node", sofapython3::doc::sofa::core::Node::docstring);
+            p(m, "Node", sofapython3::doc::sofa::core::Node::Class);
 
     /// Constructors:
     p.def(py::init([](){ return sofa::core::objectmodel::New<sofa::simulation::graph::DAGNode>("unnamed"); }),
-          ":rtype: Sofa.Simulation.Node");
+          sofapython3::doc::sofa::core::Node::init);
     p.def(py::init([](const std::string& name){
         return sofa::core::objectmodel::New<sofa::simulation::graph::DAGNode>(name);
-    }), ":rtype: Sofa.Simulation.Node", py::arg("name"));
+    }), sofapython3::doc::sofa::core::Node::init1Arg, py::arg("name"));
 
     /// Method: init (beware this is not the python __init__, this is sofa's init())
-    p.def("init", [](Node& self) { self.init(ExecParams::defaultInstance()); } );
+    p.def("init", [](Node& self) { self.init(ExecParams::defaultInstance()); }, sofapython3::doc::sofa::core::Node::initSofa );
 
     /// Method: addObjects
     /// Only addObject is needed now, the createObject is deprecated and will prints
     /// a warning for old scenes.
-    p.def("addObject", &Node_addObject, "Hello add object ...");
+    p.def("addObject", &Node_addObject, sofapython3::doc::sofa::core::Node::addObjectKwargs);
     p.def("addObject", [](Node& self, BaseObject* object) -> py::object
     {
         if(self.addObject(object))
             return PythonDownCast::toPython(object);
         return py::none();
-    });
+    }, sofapython3::doc::sofa::core::Node::addObject);
 
     p.def("createObject",
           [](Node* self, const std::string& type, const py::kwargs& kwargs) {
@@ -261,22 +261,22 @@ void moduleAddNode(py::module &m) {
                                 "To remove this warning message, use 'addObject'.";
         return Node_addObject(self, type,kwargs);
 
-    });
+    }, sofapython3::doc::sofa::core::Node::createObject);
 
     /// Method: addChild.
     /// Only addChild is needed now, the createChild is deprecated and will prints a warning for old scenes.
-    p.def("addChild", &Node_addChild, ":rtype: Sofa.Simulation.Node");
+    p.def("addChild", &Node_addChild, sofapython3::doc::sofa::core::Node::addChildKwargs);
     p.def("addChild", [](Node* self, Node* child)
     {
         self->addChild(child);
         return child;
-    }, ":rtype: Sofa.Simulation.Node");
+    }, sofapython3::doc::sofa::core::Node::addChild);
     p.def("createChild", [](Node* self, const std::string& name, const py::kwargs& kwargs)
     {
         msg_deprecated(self) << "The Node.createChild method is deprecated since sofa 19.06."
                                 "To remove this warning message, use 'addChild'.";
         return Node_addChild(self, name, kwargs);
-    });
+    }, sofapython3::doc::sofa::core::Node::createChild);
 
 
     /// Method: getChild.
@@ -286,13 +286,13 @@ void moduleAddNode(py::module &m) {
         if (child)
             return py::cast(child);
         return py::none();
-    });
+    }, sofapython3::doc::sofa::core::Node::getChild);
 
     /// Methods: removeChild
     /// Examples:
     ///     node1.removeChild(node2)
     ///     node1.removeChild("nodename")
-    p.def("removeChild", [](Node& self, Node& n){ self.removeChild(&n); });
+    p.def("removeChild", [](Node& self, Node& n){ self.removeChild(&n); }, sofapython3::doc::sofa::core::Node::removeChild);
     p.def("removeChild", [](Node& n, const std::string name)
     {
         Node* node = n.getChild(name);
@@ -301,19 +301,19 @@ void moduleAddNode(py::module &m) {
 
         n.removeChild(node);
         return py::cast(node);
-    });
+    }, sofapython3::doc::sofa::core::Node::removeChildWithName);
 
-    p.def("getRoot", &Node::getRoot);
-    p.def("getPathName", &Node::getPathName);
+    p.def("getRoot", &Node::getRoot, sofapython3::doc::sofa::core::Node::getRoot);
+    p.def("getPathName", &Node::getPathName, sofapython3::doc::sofa::core::Node::getPathName);
     p.def("getLink", [](Node* node) {
         return ("@"+node->getPathName()).c_str();
-    });
+    }, sofapython3::doc::sofa::core::Node::getLink);
 
     p.def_property_readonly("children", [](Node* node)
     {
         return new BaseIterator(node, [](Node* n) -> size_t { return n->child.size(); },
         [](Node* n, unsigned int index) -> Node::SPtr { return n->child[index]; });
-});
+}, sofapython3::doc::sofa::core::Node::children);
 
 p.def_property_readonly("parents", [](Node* node)
 {
@@ -323,7 +323,7 @@ p.def_property_readonly("parents", [](Node* node)
     auto p = n->getParents();
     return static_cast<Node*>(p[index]);
 });
-});
+}, sofapython3::doc::sofa::core::Node::parents);
 
 p.def_property_readonly("objects", [](Node* node)
 {
@@ -332,7 +332,7 @@ p.def_property_readonly("objects", [](Node* node)
     [](Node* n, unsigned int index) -> Base::SPtr {
     return (n->object[index]);
 });
-});
+}, sofapython3::doc::sofa::core::Node::objects);
 
 p.def("__getattr__", [](Node& self, const std::string& name) -> py::object
 {

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
@@ -25,7 +25,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 namespace sofapython3::doc::sofa::core::Node
 {
 
-static auto docstring =
+static auto Class =
         R"(
         Node in the scene graph
         ---------------
@@ -88,7 +88,168 @@ static auto docstring =
         :members:
         :undoc-members:
         )";
+static auto init =
+        R"(
+        Initialize the components of this node and all the nodes which depend on it.
+        :rtype: Sofa.Simulation.Node
+        )";
+
+static auto init1Arg =
+        R"(
+        Initialize the components of this node and all the nodes which depend on it.
+
+        :param name: Name of the node to be created
+        :type name: string
+        :rtype: Sofa.Simulation.Node
+        )";
+
+static auto initSofa =
+        R"(
+        Initialize the components of this node and all the nodes which depend on it.
+        (beware this is not the python __init__, this is sofa's init())
+
+        :param self: the node to initialize
+        :type self: Sofa.Simulation.Node&
+        :rtype: Sofa.Simulation.Node
+        )";
+
+static auto addObjectKwargs =
+        R"(
+        Add an object.
+        Detect the implemented interfaces and add the object to the corresponding lists.
+        :param self: the node itself
+        :param type: type of the object
+        :param kwargs
+        :type self: Sofa.Simulation.Node*
+        :type type: string&
+        :type kwargs: kwargs&
+        )";
+
+static auto addObject =
+        R"(
+        Add an object.
+        Detect the implemented interfaces and add the object to the corresponding lists.
+        :param self: the node itself
+        :param object: the object to be added
+        :type self: Sofa.Simulation.Node&
+        :type object: Sofa.Simulation.BaseObject*
+        )";
 
 
+static auto createObject =
+        R"(
+        Deprecated, see addObject
+        )";
+
+static auto addChildKwargs =
+        R"(
+        Add a child node
+        :param self: the node itself
+        :param name: name of the child to be added
+        :param kwargs
+        :type self: Sofa.Simulation.Node*
+        :type name: string&
+        :type kwargs: kwargs&
+        :rtype: Sofa.Simulation.Node
+        )";
+
+static auto addChild =
+        R"(
+        Add a child node
+
+        :param self : the node itself
+        :param child : the child to be added
+        :type self: Sofa.Simulation.Node*
+        :type child: Sofa.Simulation.Node*
+        :rtype: Sofa.Simulation.Node
+        )";
+
+static auto createChild =
+        R"(
+        Deprecated, see addChild
+        )";
+
+static auto getChild =
+        R"(
+        Get the child of a node.
+
+        :param n
+        :param name
+        :type n: Sofa.Simulation.Node
+        :type name: string
+        :return: the child of the same name
+        )";
+
+static auto removeChild =
+        R"(
+        Remove a child of a node.
+        :param self: the node itself
+        :param n: the child to remove
+        :type self: Sofa.Simulation.Node&
+        :type n: Sofa.Simulation.Node&
+        :Examples:
+        >>> node1.removeChild(node2)
+        )";
+
+static auto removeChildWithName =
+        R"(
+        Remove a child of a node.
+        :param n: the node itself
+        :param name: the name of the child to remove
+        :type n: Sofa.Simulation.Node&
+        :type name: string
+        :Examples:
+        >>> node1.removeChild("nameNode2")
+        )";
+
+static auto getRoot =
+        R"(
+        Get the root node of the current node.
+        :rtype: Sofa.Simulation.BaseNode*
+        )";
+
+static auto getPathName =
+        R"(
+        Get the path name of the current node
+        :rtype: string
+        )";
+
+static auto getLink =
+        R"(
+        Get the link of the current node
+        :param node
+        :type node: Sofa.Simulation.Node*
+        )";
+
+static auto children =
+        R"(
+        Field interface to acces the children of a node.
+
+        :Example:
+        >>> n = Sofa.Core.Node("MyNode"")
+        >>> for child in n.children:
+        >>>     print(child.name)
+        )";
+
+static auto parents =
+        R"(
+        Field interface to acces the parents of a node.
+        :Example:
+        >>> n = Sofa.Core.Node("MyNode"")
+        >>> for parent in n.parents:
+        >>>     print(parent.name)
+        )";
+static auto objects =
+        R"(
+        Field interface to acces the objects of a node.
+
+        :Example:
+        >>> n = Sofa.Core.Node("MyNode"")
+        >>> for object in n.objects:
+        >>>     print(object.name)
+        )";
 
 }
+
+
+


### PR DESCRIPTION
Add docstring documentation, which is a documentation that can be accessed in a python shell, or be used by python code.