### PR TITLE
Adds the bindings of FileRepository

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -35,6 +35,11 @@ set(HELPER_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Binding_Vector.h
     )
 
+set(HELPER_SYSTEM_HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/System/Submodule_System.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository.h
+    )
+
 set(SIMULATION_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Simulation/Submodule_Simulation.h
     )
@@ -64,6 +69,11 @@ set(TYPES_SOURCE_FILES
 set(HELPER_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/Binding_Vector.cpp
+    )
+
+set(HELPER_SYSTEM_SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/System/Submodule_System.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository.cpp
     )
 
 set(SIMULATION_SOURCE_FILES
@@ -106,6 +116,8 @@ SP3_add_python_module(
     SOURCES
         ${HELPER_SOURCE_FILES}
         ${HELPER_HEADER_FILES}
+        ${HELPER_SYSTEM_SOURCE_FILES}
+        ${HELPER_SYSTEM_HEADER_FILES}
     DEPENDS
         SofaCore SofaSimulationCore SofaSimulationGraph SofaPython3 SofaBaseVisual
     DESTINATION

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/Submodule_Helper.cpp
@@ -2,6 +2,7 @@
 #include <sofa/helper/logging/Messaging.h>
 #include <SofaPython3/PythonEnvironment.h>
 #include <sofa/core/objectmodel/Base.h>
+#include "System/Submodule_System.h"
 #include "Submodule_Helper.h"
 #include "Binding_Vector.h"
 
@@ -119,6 +120,7 @@ PYBIND11_MODULE(Helper, helper)
     helper.def("msg_fatal", [](py::args args) { MESSAGE_DISPATCH(msg_fatal); });
 
     moduleAddVector(helper);
+    moduleAddSystem(helper);
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository.cpp
@@ -1,0 +1,140 @@
+#include <pybind11/stl.h>
+#include <pybind11/iostream.h>
+#include "Binding_FileRepository.h"
+#include "Binding_FileRepository_doc.h"
+#include <sofa/helper/system/FileRepository.h>
+
+namespace py { using namespace pybind11; }
+
+
+namespace sofapython3 {
+
+void moduleAddFileRepository(py::module &m) {
+    py::class_<sofa::helper::system::FileRepository> file_repository (m, "FileRepository");
+    file_repository.doc() = doc::FileRepository::Class;
+
+    file_repository.def(
+        py::init<const char *, const char *, const char *>(),
+        py::arg("envVar") = "SOFA_DATA_PATH", py::arg("relativePath") = (const char *) nullptr, py::arg("iniFilePath") = (const char *) nullptr,
+        doc::FileRepository::ClassConstructor
+    );
+
+    file_repository.def(
+        "addFirstPath",
+        &sofa::helper::system::FileRepository::addFirstPath,
+        py::arg("path").none(false),
+        doc::FileRepository::addFirstPath
+    );
+
+    file_repository.def(
+        "addLastPath",
+        &sofa::helper::system::FileRepository::addLastPath,
+        py::arg("path").none(false),
+        doc::FileRepository::addLastPath
+    );
+
+    file_repository.def(
+        "getFirstPath",
+        &sofa::helper::system::FileRepository::getFirstPath,
+        doc::FileRepository::getFirstPath
+    );
+
+    file_repository.def(
+        "getPaths",
+        &sofa::helper::system::FileRepository::getPaths,
+        doc::FileRepository::getPaths
+    );
+
+    file_repository.def(
+        "removePath",
+        &sofa::helper::system::FileRepository::removePath,
+        py::arg("path").none(false),
+        doc::FileRepository::removePath
+    );
+
+    file_repository.def(
+        "clear",
+        &sofa::helper::system::FileRepository::clear,
+        doc::FileRepository::clear
+    );
+
+    file_repository.def_static(
+        "relativeToPath",
+        &sofa::helper::system::FileRepository::relativeToPath,
+        py::arg("path").none(false), py::arg("refPath").none(false), py::arg("doLowerCaseOnWin32") = true,
+        doc::FileRepository::relativeToPath
+    );
+
+    file_repository.def(
+        "getPathsJoined",
+        &sofa::helper::system::FileRepository::getPathsJoined,
+        doc::FileRepository::getPathsJoined
+    );
+
+    file_repository.def_property(
+        "direct_access_protocol_prefix",
+        &sofa::helper::system::FileRepository::getDirectAccessProtocolPrefix,
+        &sofa::helper::system::FileRepository::setDirectAccessProtocolPrefix,
+        doc::FileRepository::directAccessProtocolPrefix
+    );
+
+    file_repository.def(
+        "findFile",
+        [](sofa::helper::system::FileRepository & self, std::string & filename, const std::string & basedir = "") -> bool {
+            return self.findFile(filename, basedir);
+        },
+        py::arg("filename").none(false), py::arg("basedir").none(true),
+        doc::FileRepository::findFile
+    );
+
+    file_repository.def(
+        "findFile",
+        [](sofa::helper::system::FileRepository & self, std::string & filename) -> bool {
+            return self.findFile(filename);
+        },
+        py::arg("filename").none(false),
+        doc::FileRepository::findFile
+    );
+
+    file_repository.def(
+        "getFile",
+        [](sofa::helper::system::FileRepository & self, std::string & filename, const std::string & basedir = "") -> std::string {
+            return self.getFile(filename, basedir);
+        },
+        py::arg("filename").none(false), py::arg("basedir").none(true),
+        doc::FileRepository::getFile
+    );
+
+    file_repository.def(
+        "getFile",
+        [](sofa::helper::system::FileRepository & self, std::string & filename) -> std::string {
+            return self.getFile(filename);
+        },
+        py::arg("filename").none(false),
+        doc::FileRepository::getFile
+    );
+
+    file_repository.def(
+        "findFileFromFile",
+        [](sofa::helper::system::FileRepository & self, std::string & filename, const std::string & basefile = "") -> bool {
+            return self.findFileFromFile(filename, basefile);
+        },
+        py::arg("filename").none(false), py::arg("basefile").none(false),
+        doc::FileRepository::findFileFromFile
+    );
+
+    file_repository.def(
+        "print",
+        &sofa::helper::system::FileRepository::print,
+        doc::FileRepository::print
+    );
+
+    file_repository.def_static(
+        "entrySeparator",
+        &sofa::helper::system::FileRepository::entrySeparator,
+        doc::FileRepository::entrySeparator
+    );
+
+}
+
+} /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <pybind11/pybind11.h>
+
+namespace sofapython3
+{
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+namespace py { using namespace pybind11; }
+
+void moduleAddFileRepository(py::module &m);
+
+} ///sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Binding_FileRepository_doc.h
@@ -1,0 +1,113 @@
+#pragma once
+
+namespace sofapython3::doc::FileRepository
+{
+static auto Class =
+R"(
+Helper class to find files in a list of directories.
+
+Each file is searched as follow:
+
+1: Using the specified filename in current directory, or in the specified directory.
+If the filename does not start with "/", "./", or "../" :
+2: In the directory path specified using addFirstPath method.
+3: In the directory path specified using an environment variable (default to SOFA_DATA_PATH).
+4: In the default directories relative to the main executable (default to ../share).
+5: In the directory path specified using addLastPath method.
+
+For file name starting with '/', './' or '../' only the first step is used.
+A path is considered as a concatenation of directories separated by : on linux / mac and ; on windows
+
+)";
+
+static auto ClassConstructor =
+R"(
+FileRepository(envVar = 'SOFA_DATA_PATH', relativePath = None, iniFilePath = None)
+:param envVar: Every directory paths found in this environment variable will be automatically added to this file repository
+:param relativePath:
+:param iniFilePath: Every directory paths defined in this INI file will be added to this file repository
+)";
+
+static auto addFirstPath =
+R"(
+Adds a path to the front of the set of paths.
+)";
+
+static auto addLastPath =
+R"(
+Adds a path to the back of the set of paths.
+)";
+
+static auto getFirstPath =
+R"(
+Get the first path into the set of paths.
+)";
+
+static auto getPaths =
+R"(
+Get the list of directory paths included in this file repository.
+)";
+
+static auto removePath =
+R"(
+Remove a path of the set of paths.
+)";
+
+static auto clear =
+R"(
+Remove all known paths.
+)";
+
+static auto relativeToPath =
+R"(
+Returns a string such as refPath + string = path if path contains refPath.
+Otherwise returns path.
+On WIN32 the implementation was also returning the path in lower case. This behavior is now
+deprecated and should be remove the 2018-05-01. Until this date new implementation can be
+used by setting doLowerCaseOnWin32=false;
+)";
+
+static auto getPathsJoined =
+R"(
+Get the list of directory paths included in this file repository into a string separated by Sofa.Helper.System.FileRepository.entrySeparator().
+)";
+
+static auto directAccessProtocolPrefix =
+R"(
+A protocol like http: or file: which will bypass the file search if found in the filename of the findFile* functions that directly returns the path as if the function succeeded
+Use case: add the prefix ram: as the direct protocol, this way the FileRepository will not try to look for the file on the hard disk and will directly return
+then the inherited FileAccess singleton enhanced with the capacity to find ram file will deliver a correct stream to this in-ram virtual file
+)";
+
+static auto findFile =
+R"(
+Find file using the stored set of paths.
+:param basefile: override current directory by using the parent directory of the given file
+:param filename: requested file as input, resolved file path as output
+:return: true if the file was found in one of the directories, false otherwise
+)";
+
+static auto getFile =
+R"(
+Alias for findFile, but returning the resolved file as the result. Less informative for errors, but sometimes easier to use.
+)";
+
+static auto findFileFromFile =
+R"(
+Find file using the stored set of paths.
+:param basefile: override current directory by using the parent directory of the given file
+:param filename: requested file as input, resolved file path as output
+:return: true if the file was found in one of the directories, false otherwise
+)";
+
+static auto print =
+R"(
+Print the list of path to std::cout.
+)";
+
+static auto entrySeparator =
+R"(
+OS-dependant character separing entries in list of paths.
+)";
+
+} // namespace sofapython3::doc::FileRepository

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Submodule_System.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Submodule_System.cpp
@@ -1,8 +1,6 @@
 #include "Submodule_System.h"
 #include "Binding_FileRepository.h"
 
-#include <sofa/helper/system/FileRepository.h>
-
 namespace sofapython3
 {
 
@@ -11,9 +9,6 @@ void moduleAddSystem(py::module &m)
     auto system = m.def_submodule("System");
 
     moduleAddFileRepository(system);
-
-    m.add_object("DataRepository", py::cast(&sofa::helper::system::DataRepository));
-    m.add_object("PluginRepository", py::cast(&sofa::helper::system::PluginRepository));
 }
 
 } ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Submodule_System.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Submodule_System.cpp
@@ -1,0 +1,19 @@
+#include "Submodule_System.h"
+#include "Binding_FileRepository.h"
+
+#include <sofa/helper/system/FileRepository.h>
+
+namespace sofapython3
+{
+
+void moduleAddSystem(py::module &m)
+{
+    auto system = m.def_submodule("System");
+
+    moduleAddFileRepository(system);
+
+    m.add_object("DataRepository", py::cast(&sofa::helper::system::DataRepository));
+    m.add_object("PluginRepository", py::cast(&sofa::helper::system::PluginRepository));
+}
+
+} ///namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Submodule_System.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Helper/System/Submodule_System.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <pybind11/pybind11.h>
+
+namespace sofapython3
+{
+namespace py { using namespace pybind11; }
+
+void moduleAddSystem(py::module &m);
+
+} /// namespace sofapython3
+

--- a/bindings/Sofa/tests/Helper/FileRepository.py
+++ b/bindings/Sofa/tests/Helper/FileRepository.py
@@ -1,0 +1,56 @@
+# coding: utf8
+
+import Sofa
+import Sofa.Helper
+import unittest
+import tempfile
+import os
+
+
+class Test(unittest.TestCase):
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+        self.temp_dir1 = tempfile.TemporaryDirectory(suffix="Test", prefix="FileRepository")
+        self.temp_file1 = open(os.path.join(self.temp_dir1.name, "a_simple_test_file_1.txt"), "w")
+
+        self.temp_dir2 = tempfile.TemporaryDirectory(suffix="Test", prefix="FileRepository")
+        self.temp_file2 = open(os.path.join(self.temp_dir2.name, "a_simple_test_file_2.txt"), "w")
+
+        os.environ['FILEREPOSITORYTEST'] = self.temp_dir1.name
+        self.repository = Sofa.Helper.System.FileRepository("FILEREPOSITORYTEST")
+        self.assertEqual(self.repository.getPaths(), [self.temp_dir1.name])
+        self.repository.clear()
+        self.assertEqual(self.repository.getPaths(), [])
+
+    def test_add_remove_directories(self):
+        self.repository.addFirstPath(self.temp_dir1.name)
+        self.repository.addFirstPath(self.temp_dir2.name)
+        self.assertEqual(self.repository.getPaths(), [self.temp_dir2.name, self.temp_dir1.name])
+
+        self.repository.removePath(self.temp_dir2.name)
+        self.assertEqual(self.repository.getPaths(), [self.temp_dir1.name])
+
+        self.repository.addLastPath(self.temp_dir2.name)
+        self.assertEqual(self.repository.getPaths(), [self.temp_dir1.name, self.temp_dir2.name])
+
+        self.repository.clear()
+
+    def test_find_file(self):
+        self.repository.addFirstPath(self.temp_dir1.name)
+        self.assertTrue(self.repository.findFile("a_simple_test_file_1.txt"))
+        self.repository.addFirstPath(self.temp_dir2.name)
+        self.assertTrue(self.repository.findFile("a_simple_test_file_2.txt"))
+
+        self.assertEqual(self.repository.getFile("a_simple_test_file_1.txt"), os.path.join(self.temp_dir1.name, "a_simple_test_file_1.txt"))
+        self.assertEqual(self.repository.getFile("a_simple_test_file_21.txt"), os.path.join(self.temp_dir2.name, "a_simple_test_file_2.txt"))
+
+        self.repository.clear()
+
+
+def runTests():
+    suite = unittest.TestLoader().loadTestsFromTestCase(Test)
+    return unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
+
+
+def createScene(rootNode):
+    runTests()

--- a/bindings/Sofa/tests/Helper/FileRepository.py
+++ b/bindings/Sofa/tests/Helper/FileRepository.py
@@ -42,7 +42,7 @@ class Test(unittest.TestCase):
         self.assertTrue(self.repository.findFile("a_simple_test_file_2.txt"))
 
         self.assertEqual(self.repository.getFile("a_simple_test_file_1.txt"), os.path.join(self.temp_dir1.name, "a_simple_test_file_1.txt"))
-        self.assertEqual(self.repository.getFile("a_simple_test_file_21.txt"), os.path.join(self.temp_dir2.name, "a_simple_test_file_2.txt"))
+        self.assertEqual(self.repository.getFile("a_simple_test_file_2.txt"), os.path.join(self.temp_dir2.name, "a_simple_test_file_2.txt"))
 
         self.repository.clear()
 

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
@@ -29,6 +29,8 @@ using sofapython3::SceneLoaderPY3;
 #include <SofaSimulationCommon/init.h>
 #include <SofaSimulationGraph/init.h>
 
+#include <sofa/helper/system/FileRepository.h>
+
 #include <SofaPython3/Sofa/Core/Binding_Base.h>
 #include <SofaPython3/Sofa/Core/Binding_Node.h>
 #include <SofaPython3/Sofa/Core/Binding_Simulation.h>
@@ -103,6 +105,9 @@ PYBIND11_MODULE(SofaRuntime, m) {
     {
         return simpleapi::importPlugin(name);
     });
+
+    m.add_object("DataRepository", py::cast(&sofa::helper::system::DataRepository));
+    m.add_object("PluginRepository", py::cast(&sofa::helper::system::PluginRepository));
 
     addSubmoduleInput(m);
     addSubmoduleTimer(m);


### PR DESCRIPTION
With this PR, you should now be able to create file repositories, and access the Sofa's global repositories `PluginRepository` and `DataRepository`

Example of a typical use:

```
import Sofa.Helper
import SofaRuntime
Sofa.Helper.PluginRepository.addFirstPath("/home/jnbrunet/sources/sofa/build/lib")
SofaRuntime.importPlugin("SofaAllCommonComponents")
```

Edit:

Global variables are now in `SofaRuntime`, so the example above is now:
```
import Sofa.Helper
import SofaRuntime
SofaRuntime.PluginRepository.addFirstPath("/home/jnbrunet/sources/sofa/build/lib")
SofaRuntime.importPlugin("SofaAllCommonComponents")
```