### PR TITLE
New binding base object

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject.cpp
@@ -46,8 +46,8 @@ py::object getItem(const BaseObject& self, const std::string& path)
     throw py::value_error("Invalid syntax"); // should never get there
 }
 
-std::string getLinkPath(const BaseObject *self, py::arg args){
-    return std::string("@")+self->getPathName().c_str();
+std::string getLinkPath(const BaseObject *self){
+    return std::string("@")+self->getPathName();
 };
 
 void moduleAddBaseObject(py::module& m)
@@ -179,8 +179,8 @@ void moduleAddBaseObject(py::module& m)
         self->computeBBox(sofa::core::ExecParams::defaultInstance(), false);
     }, sofapython3::doc::baseObject::computeBBox);
     p.def("getLinkPath", &getLinkPath, sofapython3::doc::baseObject::getLinkPath);
-    p.def("getAsACreateObjectParameter", [](BaseObject *self, py::arg args){
-        return getLinkPath(self, args);
+    p.def("getAsACreateObjectParameter", [](BaseObject *self){
+        return getLinkPath(self);
     }, sofapython3::doc::baseObject::getAsACreateObjectParameter);
     p.def("setSrc", [](BaseObject &self, char *valueString, BaseObject *loader){
         self.setSrc(valueString,loader);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseObject_doc.h
@@ -52,4 +52,92 @@ static auto getLink =
         :type self: baseObject
         :rtype: string
         )";
+
+static auto getSlaves =
+        R"(
+        Return the slaves of the baseObject.
+        :rtype: list
+        )";
+
+static auto getContext =
+        R"(
+        Return the conext of the baseObject.
+        :rtype: BaseContext
+        )";
+
+static auto getMaster =
+        R"(
+        Return the master of the baseObject.
+        :rtype: BaseObject
+        )";
+
+static auto addSlave =
+        R"(
+        Add a slave to the master BaseObject.
+        :param slave: the slave to be added.
+        :type slave: BaseObject
+        )";
+
+static auto storeResetState =
+        R"(
+        Save the initial state for later uses in reset()
+        )";
+
+static auto reset =
+        R"(
+        Reset to initial state.
+        To save the initial state, see storeResetState().
+        )";
+
+static auto getName =
+        R"(
+        Accessor to the baseObject name.
+        :rtype: string
+        )";
+
+static auto getTarget =
+        R"(
+        Return the target (plugin) that contains the current baseObject.
+        :rtype: string
+        )";
+
+static auto getCategories =
+        R"(
+        Return the list of categories the current object belongs to.
+        :rtype: list
+        )";
+static auto setSrc =
+        R"(
+        Set a source Object and parses it to collect dependent Data.
+        )";
+
+static auto bwdInit =
+        R"(
+        Initialization method called at graph creation and modification, during bottom-up traversal.
+        )";
+
+static auto cleanup =
+        R"(
+        Called just before deleting this object
+        Any object in the tree bellow this object that are to be removed will be removed only after this call,
+        so any references this object holds should still be valid.
+        )";
+
+static auto computeBBox =
+        R"(
+        Bounding Box computation method.
+        Default to empty method.
+        )";
+
+static auto getLinkPath =
+        R"(
+        Return the full path name of this baseObject with an extra prefix '@'
+        :rtype: string
+        )";
+
+static auto getAsACreateObjectParameter =
+        R"(
+        Return the full path name of this baseObject with an extra prefix '@'
+        :rtype: string
+        )";
 }

--- a/bindings/Sofa/tests/Binding_BaseObject_MockComponent.cpp
+++ b/bindings/Sofa/tests/Binding_BaseObject_MockComponent.cpp
@@ -1,0 +1,42 @@
+#include "Binding_BaseObject_MockComponent.h"
+#include <sofa/core/ObjectFactory.h>
+
+
+Binding_BaseObject_MockComponent::Binding_BaseObject_MockComponent():
+d_test(initData(&d_test, std::string(""), "test", "This data should have the value of the last called method in the test."))
+{
+}
+Binding_BaseObject_MockComponent::~Binding_BaseObject_MockComponent()
+{
+
+}
+void Binding_BaseObject_MockComponent::bwdInit(){
+    d_test.setValue("bwdInit");
+}
+void Binding_BaseObject_MockComponent::cleanup(){
+    d_test.setValue("cleanup");
+}
+void Binding_BaseObject_MockComponent::computeBBox(const sofa::core::ExecParams* /* params */, bool /*onlyVisible*/){
+    d_test.setValue("computeBBox");
+}
+
+void Binding_BaseObject_MockComponent::storeResetState(){
+    d_test.setValue("storeResetState");
+}
+
+void Binding_BaseObject_MockComponent::reset(){
+    d_test.setValue("reset");
+}
+
+void Binding_BaseObject_MockComponent::init(){
+    d_test.setValue("init");
+}
+
+void Binding_BaseObject_MockComponent::reinit(){
+    d_test.setValue("reinit");
+}
+
+
+
+int Binding_BaseObject_MockComponentClass = sofa::core::RegisterObject("This component is used to test several functions of Binding_BaseObject")
+        .add< Binding_BaseObject_MockComponent >();

--- a/bindings/Sofa/tests/Binding_BaseObject_MockComponent.h
+++ b/bindings/Sofa/tests/Binding_BaseObject_MockComponent.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <sofa/core/objectmodel/BaseObject.h>
+
+
+
+
+class Binding_BaseObject_MockComponent : public sofa::core::objectmodel::BaseObject
+{
+public:
+SOFA_CLASS(Binding_BaseObject_MockComponent, sofa::core::objectmodel::BaseObject);
+        sofa::core::objectmodel::Data <std::string> d_test;
+
+        Binding_BaseObject_MockComponent ();
+        virtual ~Binding_BaseObject_MockComponent () override;
+        void bwdInit() override;
+        void cleanup() override;
+        void computeBBox(const sofa::core::ExecParams* /* params */, bool /*onlyVisible*/=false) override;
+        //void setSrc(const std::string &v, const BaseObject *loader, std::vector< std::string > *attributeList=nullptr);
+        void storeResetState() override;
+        void reset() override;
+        void init() override;
+        void reinit() override;
+};
+

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -17,9 +17,17 @@ message("-- PythonModule_Sofa_test is enabled.")
 ####################################################################################################
 ### Building
 ####################################################################################################
+set(HEADER_FILES
+    Binding_BaseObject_MockComponent.h
+)
+
+
 set(SOURCE_FILES
     PythonModule_Sofa_test.cpp
+    Binding_BaseObject_MockComponent.cpp
 )
+
+
 
 set(PYTHON_FILES
     Components/Components.py
@@ -42,7 +50,7 @@ set(PYTHON_FILES
 
 find_package(SofaGTestMain REQUIRED)
 
-add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${PYTHON_FILES})
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES} ${PYTHON_FILES})
 target_link_libraries(${PROJECT_NAME} SofaGTestMain SofaPython3 SofaPython3_Sofa_Types SofaPython3_Sofa_Simulation SofaPython3_Sofa_Helper SofaPython3_Sofa_Core)
 target_compile_definitions(${PROJECT_NAME} PRIVATE "PYTHON_TESTFILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/\"")
 

--- a/bindings/Sofa/tests/Core/BaseObject.py
+++ b/bindings/Sofa/tests/Core/BaseObject.py
@@ -32,6 +32,65 @@ class Test(unittest.TestCase):
                 self.assertFalse(hasattr(c.__data__, "invalidEntry"))
                 self.assertTrue(isinstance(c.__data__, Sofa.Core.DataDict))
 
+        def test_context(self):
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("MechanicalObject", name="t", position=[[0,0,0],[1,1,1],[2,2,2]])
+                self.assertTrue(c.getContext() is not None)
+
+        def test_slave_master(self):
+                root = Sofa.Core.Node("rootNode")
+                c_master = root.addObject("MechanicalObject", name="t_master", position=[[0,0,0],[1,1,1],[2,2,2]])
+                c_slave = root.addObject("MechanicalObject", name="t_slave", position=[[0,0,0],[1,1,1],[2,2,2]])
+                c_master.addSlave(c_slave)
+                self.assertEqual(c_master,c_slave.getMaster())
+                self.assertEqual(c_master.getSlaves()[0],c_slave)
+                self.assertEqual(c_slave.getSlaves(),[])
+
+        def test_getTarget(self):
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("MechanicalObject", name="t")
+                self.assertEqual(c.getTarget(),'SofaBaseMechanics')
+
+        def test_getName(self):
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("MechanicalObject", name="t")
+                self.assertEqual(c.getName(),"t")
+
+        def test_getCategories(self):
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("MechanicalObject", name="t")
+                self.assertEqual(c.getCategories(),["MechanicalState"])
+
+        def test_getPathName(self):
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("MechanicalObject", name="t")
+                self.assertEqual(c.getPathName(),"/t")
+
+        def test_getLinkPath(self):
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("MechanicalObject", name="t")
+                self.assertEqual(c.getLinkPath(),"@/t")
+                self.assertEqual(c.getAsACreateObjectParameter(), "@/t")
+
+        def test_setSrc(self):
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("Binding_BaseObject_MockComponent", name="t")
+                loader = root.addObject("Binding_BaseObject_MockComponent", name="loader")
+                loader.test = "setSrc"
+                c.setSrc("test",loader)
+                self.assertEqual(c.test.value, loader.test.value)
+
+        def test_mockComponent(self):
+                # Test several binded functions using the Binding_BaseObject_MockComponent
+                t = ["bwdInit", "cleanup", "computeBBox", "storeResetState", "reset", "init", "reinit"]
+                root = Sofa.Core.Node("rootNode")
+                c = root.addObject("Binding_BaseObject_MockComponent", name="t")
+                for name in t:
+                    print(name)
+                    getattr(c,name)()
+                    self.assertEqual(c.test.value,name)
+
+
 def getTestsName():
     suite = unittest.TestLoader().loadTestsFromTestCase(Test)
     return [ test.id().split(".")[2] for test in suite]


### PR DESCRIPTION
All the functions binded in SofaPython for BaseObject are now also binded in SofaPython3.
Every function has docstring documentation, and the bindings are tested.
A new component was created : Binding_BaseObject_MockComponent, that inherits from BaseObject. It is used to test the bindings of virtual functions of BaseObject. It has only one attribute, a data string. In order to test a virtual function, the function is implemented in the Mock Component, and simply changes the value of the data string to the name of the function itself. That way, it is simple to check in the test script in Python whether the function was called or not, by simply looking at the value of the data string.