### PR TITLE
Add python forcefields

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
@@ -89,11 +89,10 @@ static auto getLinks =
 
 static auto addData =
         R"(
-        Create a data field, then adds it to the base.
+        Creates a data field, then adds it to the base.
         Note that this method should only be called if the field was not initialized with the initData method
-        :param self: the base itself
         :param name: the name of the data to be added
-        :param value: the value from which the data can be created
+        :param value: the value from which the data can be initialized
         :param help: help message that describes the data to be created
         :param group: the group the data belongs to
         :param type: the type of the data
@@ -109,8 +108,7 @@ static auto addDataInitialized =
         R"(
         Add a data field.
         Note that this method should only be called if the field was not initialized with the initData method
-        :param self: the base itself
-        :param d: the data to be added
+        :param d: the data to be added to self
         :type self: Base*
         :type d: object
         )";

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
@@ -8,24 +8,27 @@
 #include <sofa/core/behavior/ForceField.h>
 #include <sofa/simulation/Node.h>
 
+
+using sofa::core::behavior::BaseForceField;
+using sofa::core::behavior::MultiMatrixAccessor;
+using sofa::core::MechanicalParams;
+using sofa::core::MultiVecDerivId;
+
 PYBIND11_DECLARE_HOLDER_TYPE(TForceField,
                              sofapython3::py_shared_ptr<TForceField>, true)
 
 
 namespace sofapython3
 {
-using sofa::core::objectmodel::ComponentState;
-using sofa::core::behavior::MechanicalState;
-using sofa::core::behavior::ForceField;
-using sofa::defaulttype::Vec3dTypes;
+    using sofa::core::objectmodel::ComponentState;
+    using sofa::core::behavior::MechanicalState;
+    using sofa::core::behavior::ForceField;
+    using sofa::defaulttype::Vec3dTypes;
 
-class ForceField_Trampoline  : public ForceField<Vec3dTypes>, public PythonTrampoline
-{
-public:
-    ForceField_Trampoline() = default;
-    ~ForceField_Trampoline() override = default;
+    ForceField_Trampoline::ForceField_Trampoline() = default;
+    ForceField_Trampoline::~ForceField_Trampoline() = default;
 
-    void init() override
+    void ForceField_Trampoline::init()
     {
         ForceField<Vec3dTypes>::init();
 
@@ -38,87 +41,129 @@ public:
         PYBIND11_OVERLOAD(void, ForceField, init,);
     }
 
-    void addForce(const MechanicalParams* mparams,  DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override
+    // pass bFactor, kFactor, readX, readV, readF, energy
+    void ForceField_Trampoline::addForce(const MechanicalParams* mparams,  DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v)
     {
-        auto xx = const_cast<BaseData*>(static_cast<const BaseData*>(&x));
-        auto vv = const_cast<BaseData*>(static_cast<const BaseData*>(&v));
-        PYBIND11_OVERLOAD_PURE(void, ForceField, addForce, py::none(), toPython(&f,true), toPython(xx,true), toPython(vv,true));
+        // pass bFactor, kFactor, energy
+        py::dict mp = py::dict("mFactor"_a=mparams->mFactor(),
+                               "bFactor"_a=mparams->bFactor(),
+                               "kFactor"_a=mparams->kFactor(),
+                               "energy"_a=mparams->energy());
+        PYBIND11_OVERLOAD_PURE(void, ForceField, addForce, toPython(&f,true), toPython(&x), toPython(&v), mp);
     }
 
-    void addDForce(const MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx ) override
+    // pass mFactor, kFactor
+    void ForceField_Trampoline::addDForce(const MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx )
     {
-        auto dxx = const_cast<BaseData*>(static_cast<const BaseData*>(&dx));
-        PYBIND11_OVERLOAD_PURE(void, ForceField, addDForce,
-                               toPython(&df,true), toPython(dxx,true),
-                               py::cast(mparams->kFactor()), py::cast(mparams->bFactor()));
+        // pass bFactor, kFactor, energy
+        py::dict mp = py::dict("nFactor"_a=mparams->mFactor(),
+                               "bFactor"_a=mparams->bFactor(),
+                               "kFactor"_a=mparams->kFactor());
+        PYBIND11_OVERLOAD_PURE(void, ForceField, addDForce, toPython(&df,true), toPython(&dx), mp);
     }
 
-    /*virtual void addMBKdx(const MechanicalParams* mparams, MultiVecDerivId dfId) override
+    py::object ForceField_Trampoline::_addKToMatrix(const MechanicalParams* mparams, int nIndices, int nDofs)
     {
-        PYBIND11_OVERLOAD_PURE(void, ForceField, addMBKdx, py::none(), py::none() );
-    }*/
-    void addKToMatrix(const MechanicalParams* mparams, const MultiMatrixAccessor* dfId) override
-    {
-        PYBIND11_OVERLOAD_PURE(void, ForceField, addKToMatrix, py::none(), py::none() );
+        py::dict mp = py::dict("mFactor"_a=mparams->mFactor(),
+                               "bFactor"_a=mparams->bFactor(),
+                               "kFactor"_a=mparams->kFactor());
+
+        PYBIND11_OVERLOAD_PURE(py::object, ForceField, addKToMatrix, nIndices, nDofs, mp);
     }
 
-    void updateForceMask() override
+    // pass k/b/mFactor
+    void ForceField_Trampoline::addKToMatrix(const MechanicalParams* mparams, const MultiMatrixAccessor* dfId)
     {
-        #ifdef SOFA_USE_MASK
-            PYBIND11_OVERLOAD_PURE(void, ForceField, updateForceMask,);
-        #else
-           PYBIND11_OVERLOAD(void, ForceField, updateForceMask,);
-        #endif
+        MultiMatrixAccessor::MatrixRef mref = dfId->getMatrix(this->mstate);
+        sofa::defaulttype::BaseMatrix* mat = mref.matrix;
+
+        int offset = int(mref.offset);
+        // nNodes is the number of nodes (positions) of the object whose K matrix we're computing
+        int nNodes = int(mparams->readX(mstate)->getValue().size());
+        // nDofs is the number of degrees of freedom per-element of the object whose K matrix we're computing
+        int nDofs = Coord::total_size;
+
+        py::object ret = _addKToMatrix(mparams, nNodes, nDofs);
+
+        // if ret is numpy array
+        if(py::isinstance<py::array>(ret))
+        {
+            auto r = py::cast<py::array>(ret);
+            if (r.ndim() == 2)
+            {
+                // read K as a plain 2D matrix
+                auto kMatrix = r.unchecked<double, 2>();
+                for (auto x = 0 ; x < kMatrix.shape(0) ; ++x)
+                {
+                    for (auto y = 0 ; y < kMatrix.shape(1) ; ++y)
+                    {
+                        mat->add(offset + x, offset + y, kMatrix(x,y));
+                    }
+                }
+            }
+            else if (r.ndim() == 1)
+            {
+                // consider ret to be a list of tuples [(i,j,[val])]
+                auto kMatrix = r.unchecked<py::object, 1>();
+                for (auto x = 0 ; x < kMatrix.size() ; ++x)
+                {
+                    py::tuple tuple = py::cast<py::tuple>(kMatrix(x));
+                    if (tuple.size() != 3)
+                        throw py::type_error("When returning a 1D numpy array in AddKToMatrix, elements must be tuples following the following structure: (i, j, val)");
+                    mat->add(offset + py::cast<int>(tuple[0]), offset + py::cast<int>(tuple[1]), py::cast<double>(tuple[2]));
+                }
+            }
+            else
+            {
+                throw py::type_error("Can't read return value of AddKToMatrix. The method should return either a plain 2D matrix or a vector of tuples (i, j, val)");
+            }
+        }
     }
 
-    SReal getPotentialEnergy( const MechanicalParams* mparams, const DataVecCoord& x) const override { return 0.0; }
-
-
-    std::string getClassName() const override
+    std::string ForceField_Trampoline::getClassName() const
     {
         return pyobject->ob_type->tp_name;
     }
-};
 
-
-void moduleAddForceField(py::module &m) {
-    py::class_<ForceField<Vec3dTypes>,
-            ForceField_Trampoline, BaseObject,
-            py_shared_ptr<ForceField<Vec3dTypes>>> f(m, "ForceField",
-                                                     py::dynamic_attr(),
-                                                     py::multiple_inheritance());
-
-    f.def(py::init([](py::args& args, py::kwargs& kwargs)
+    void moduleAddForceField(py::module &m)
     {
-              auto c = new ForceField_Trampoline();
-              c->f_listening.setValue(true);
+        py::class_<ForceField<Vec3dTypes>,
+                BaseObject, ForceField_Trampoline,
+                py_shared_ptr<ForceField<Vec3dTypes>>> f(m, "ForceField",
+                                                         py::dynamic_attr(),
+                                                         py::multiple_inheritance());
 
-              if(args.size() != 0)
-              {
-                  if(args.size()==1) c->setName(py::cast<std::string>(args[0]));
-                  else throw py::type_error("Only one un-named arguments can be provided.");
-              }
+        f.def(py::init([](py::args& args, py::kwargs& kwargs)
+        {
+                  std::cout << "Creating Trampoline" << std::endl;
+                  auto c = new ForceField_Trampoline();
+                  std::cout << "setting event listening to true" << std::endl;
+                  c->f_listening.setValue(true);
 
-              py::object cc = py::cast(c);
-              for(auto kv : kwargs)
-              {
-                  std::string key = py::cast<std::string>(kv.first);
-                  py::object value = py::reinterpret_borrow<py::object>(kv.second);
-                  if( key == "name")
+                  std::cout << "Checking arguments" << std::endl;
+                  if(args.size() != 0)
                   {
-                      if( args.size() != 0 )
-                      {
-                          throw py::type_error("The name is setted twice as a "
-                          "named argument='"+py::cast<std::string>(value)+"' and as a"
-                          "positional argument='"+py::cast<std::string>(args[0])+"'.");
-                      }
+                      if(args.size()==1) c->setName(py::cast<std::string>(args[0]));
+                      else throw py::type_error("Only one un-named arguments can be provided.");
                   }
-                  BindingBase::SetAttr(cc, key, value);
-              }
-              return c;
-          }));
-}
 
-
-
+                  py::object cc = py::cast(c);
+                  for(auto kv : kwargs)
+                  {
+                      std::string key = py::cast<std::string>(kv.first);
+                      py::object value = py::reinterpret_borrow<py::object>(kv.second);
+                      if( key == "name")
+                      {
+                          if( args.size() != 0 )
+                          {
+                              throw py::type_error("The name is setted twice as a "
+                              "named argument='"+py::cast<std::string>(value)+"' and as a"
+                              "positional argument='"+py::cast<std::string>(args[0])+"'.");
+                          }
+                      }
+                      BindingBase::SetAttr(cc, key, value);
+                  }
+                  return c;
+              }));
+    }
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
@@ -49,7 +49,7 @@ namespace sofapython3
                                "bFactor"_a=mparams->bFactor(),
                                "kFactor"_a=mparams->kFactor(),
                                "energy"_a=mparams->energy());
-        PYBIND11_OVERLOAD_PURE(void, ForceField, addForce, toPython(&f,true), toPython(&x), toPython(&v), mp);
+        PYBIND11_OVERLOAD_PURE(void, ForceField, addForce, mp, toPython(&f,true), toPython(&x), toPython(&v));
     }
 
     // pass mFactor, kFactor
@@ -59,7 +59,7 @@ namespace sofapython3
         py::dict mp = py::dict("nFactor"_a=mparams->mFactor(),
                                "bFactor"_a=mparams->bFactor(),
                                "kFactor"_a=mparams->kFactor());
-        PYBIND11_OVERLOAD_PURE(void, ForceField, addDForce, toPython(&df,true), toPython(&dx), mp);
+        PYBIND11_OVERLOAD_PURE(void, ForceField, addDForce, mp, toPython(&df,true), toPython(&dx));
     }
 
     py::object ForceField_Trampoline::_addKToMatrix(const MechanicalParams* mparams, int nIndices, int nDofs)
@@ -68,7 +68,7 @@ namespace sofapython3
                                "bFactor"_a=mparams->bFactor(),
                                "kFactor"_a=mparams->kFactor());
 
-        PYBIND11_OVERLOAD_PURE(py::object, ForceField, addKToMatrix, nIndices, nDofs, mp);
+        PYBIND11_OVERLOAD_PURE(py::object, ForceField, addKToMatrix, mp, nIndices, nDofs);
     }
 
     // pass k/b/mFactor

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
@@ -1,22 +1,41 @@
 #pragma once
 
-#include "Binding_BaseObject.h"
-
 #include <sofa/core/behavior/BaseForceField.h>
+#include <sofa/core/behavior/ForceField.h>
+#include <sofa/defaulttype/VecTypes.h>
+#include <sofa/core/MechanicalParams.h>
 
-
-//template class pybind11::class_<
-//                          sofa::core::behavior::BaseForceField,
-//                          sofa::core::objectmodel::BaseObject,
-//                          sofa::core::sptr<sofa::core::behavior::BaseForceField>>;
+#include "Binding_BaseObject.h"
+#include <SofaPython3/DataHelper.h>
 
 namespace sofapython3
 {
-using sofa::core::behavior::BaseForceField;
-using sofa::core::behavior::MultiMatrixAccessor;
-using sofa::core::MechanicalParams;
-using sofa::core::MultiVecDerivId;
+
+class ForceField_Trampoline  : public sofa::core::behavior::ForceField<sofa::defaulttype::Vec3dTypes>, public PythonTrampoline
+{
+public:
+    ForceField_Trampoline();
+    ~ForceField_Trampoline() override;
+
+    void init() override;
+
+    void addForce(const sofa::core::MechanicalParams* mparams,  DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
+
+    void addDForce(const sofa::core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx ) override;
+
+    py::object _addKToMatrix(const sofa::core::MechanicalParams* mparams, int nNodes, int nDofs);
+    void addKToMatrix(const sofa::core::MechanicalParams* mparams, const sofa::core::behavior::MultiMatrixAccessor* dfId) override;
+
+    SReal getPotentialEnergy(const sofa::core::MechanicalParams* /*mparams*/, const DataVecCoord& /*x*/) const override { return 0.0; }
+
+    std::string getClassName() const override;
+};
 
 void moduleAddForceField(py::module &m);
 
 } /// namespace sofapython3
+
+//template class pybind11::class_<sofa::core::behavior::ForceField<sofa::defaulttype::Vec3dTypes>,
+//                    sofa::core::objectmodel::BaseObject, sofapython3::ForceField_Trampoline,
+//                    sofapython3::py_shared_ptr<sofa::core::behavior::ForceField<sofa::defaulttype::Vec3dTypes>>>;
+

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -64,9 +64,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddBaseCamera(core);
     moduleAddBaseData(core);
     moduleAddWriteAccessor(core);
-    std::cout << "0" << std::endl;
     moduleAddDataContainer(core);
-    std::cout << "1" << std::endl;
     moduleAddBaseObject(core);
     moduleAddController(core);
     moduleAddForceField(core);

--- a/bindings/Sofa/tests/Core/MyRestShapeForceField.py
+++ b/bindings/Sofa/tests/Core/MyRestShapeForceField.py
@@ -1,0 +1,61 @@
+import Sofa
+import Sofa.Core
+import numpy as np
+
+
+class MyRestShapeSpringsForcefield(Sofa.Core.ForceField):
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.ForceField.__init__(self, *args, **kwargs)
+
+        if kwargs.get("stiffness") is not None:
+            self.addData(name="stiffness", value=kwargs.get("stiffness"), type="double",
+                         help="scalar value representing the stiffness between"
+                              "the actual position and the rest shape position")
+        self.addData(name="rest_pos", value=kwargs.get("rest_pos"))
+
+    def init(self):
+        try:
+            hasattr(self, "indices")
+        except:
+            self.indices = range(0, len(self.rest_pos.value))
+
+    def addForce(self, m, forces, pos, vel):
+        print("addForce")
+        k = self.stiffness.value
+        for index in self.indices:
+            forces[index] -= (pos[index] - self.rest_pos.value[index]) * k
+
+    def addDForce(self, m, dforce, dx):
+        print("addDForce")
+        # kFactorIncludingRayleighDamping -> assuming rayleighStiffness of 0.0
+        # kF = mparams['kFactor'] + mparams['bFactor'] * self.rayleighStiffness.value
+        k = self.stiffness.value * m['kFactor']
+        for index in self.indices:
+            dforce[index] -= dx[index] * k
+
+    def _addKToMatrix_selectivePoints(self, mparams, nNodes, nDofs):
+        K = []
+
+        # kFactorIncludingRayleighDamping => rayleighStiffness = 0.0
+        kF = mparams['kFactor'] + mparams['bFactor'] * 0.0
+
+        for index in self.indices:
+            for n in range(0, nDofs):
+                K.append([nDofs * index + n, nDofs * index +
+                          n, -kF * self.stiffness.value])
+        return np.asarray(K)
+
+    def _addKToMatrix_plainMatrix(self, mparams, nNodes, nDofs):
+        K = np.zeros((nNodes * nDofs, nNodes * nDofs, 1), dtype=float)
+        # kFactorIncludingRayleighDamping => rayleighStiffness = 0.0
+        kF = mparams['kFactor'] + mparams['bFactor'] * 0.0
+
+        for idx in self.indices:
+            for n in range(0, nDofs):
+                K[nDofs * idx + n, nDofs * idx + n] = -kF * self.stiffness.value
+        return K
+
+    def addKToMatrix(self, mparams, nNodes, nDofs):
+        print("addKToMatrix")
+        # self.K = self._addKToMatrix_selectivePoints(mparams, nNodes, nDofs)
+        return self._addKToMatrix_plainMatrix(mparams, nNodes, nDofs)

--- a/bindings/Sofa/tests/Core/testForceField.py3
+++ b/bindings/Sofa/tests/Core/testForceField.py3
@@ -1,0 +1,87 @@
+from MyRestShapeForceField import MyRestShapeSpringsForcefield
+
+
+def createIntegrationScheme(node, use_implicit_scheme):
+    if use_implicit_scheme is True:
+        node.addObject('EulerImplicitSolver', name='odeImplicitSolver',
+                       rayleighStiffness='0.1', rayleighMass='0.1')
+    else:
+        node.addObject('EulerExplicitSolver', name='odeExplicitSolver')
+
+
+def createSolver(node, use_iterative_solver):
+    if use_iterative_solver is True:
+        node.addObject('CGLinearSolver', name='linearSolver',
+                       iterations=30, tolerance=1.e-9, threshold=1.e-9)
+    else:
+        node.addObject('SparseLDLSolver', name='ldlSolver')
+
+
+def createDragon(node, node_name, use_implicit_scheme, use_iterative_solver):
+    dragon = node.addChild(node_name)
+    createIntegrationScheme(dragon, use_implicit_scheme)
+    createSolver(dragon, use_iterative_solver)
+    dragon.addObject('SparseGridTopology', n=[
+                     10, 5, 10], fileTopology="mesh/dragon.obj")
+    dofs = dragon.addObject(
+        'MechanicalObject', name="DOFs")
+    dragon.addObject('UniformMass', totalMass=1.0)
+
+    myRSSFF = MyRestShapeSpringsForcefield(name="Springs",
+                                           stiffness=50,
+                                           mstate=dofs, rest_pos=dofs.rest_position)
+    dragon.addObject(myRSSFF)
+
+    visu = dragon.addChild("Visu")
+    vm = visu.addObject('OglModel', fileMesh="mesh/dragon.obj",
+                        color=[1.0, 0.5, 1.0, 1.0])
+    visu.addObject('BarycentricMapping',
+                   input=dofs.getLink(), output=vm.getLink())
+
+    collision = dragon.addChild("Collis")
+    collision.addObject('MeshObjLoader', name="loader",
+                        filename="mesh/dragon.obj")
+    collision.addObject('Mesh', src="@loader")
+    collision.addObject('MechanicalObject', src="@loader")
+    collision.addObject('TriangleCollisionModel', group="1")
+    collision.addObject('LineCollisionModel', group="1")
+    collision.addObject('PointCollisionModel', group="1")
+    collision.addObject('BarycentricMapping', input="@..", output="@.")
+
+
+def createCube(node, node_name, use_implicit_scheme, use_iterative_solver):
+    cube = node.addChild(node_name)
+    createIntegrationScheme(cube, use_implicit_scheme)
+    createSolver(cube, use_iterative_solver)
+    cube.addObject('SparseGridTopology', n=[
+                   2, 2, 2], fileTopology="mesh/smCube27.obj")
+    dofs = cube.addObject('MechanicalObject', name="DOFs", dy=20)
+    cube.addObject('UniformMass', totalMass=1.0)
+
+    myRSSFF = MyRestShapeSpringsForcefield(name="Springs",
+                                           stiffness=50,
+                                           mstate=dofs, rest_pos=dofs.rest_position)
+    cube.addObject(myRSSFF)
+
+    visu = cube.addChild("Visu")
+    vm = visu.addObject(
+        'OglModel', fileMesh="mesh/smCube27.obj", color=[0.5, 1.0, 0.5, 1.0])
+    visu.addObject('BarycentricMapping',
+                   input=dofs.getLink(), output=vm.getLink())
+
+    collision = cube.addChild("Collis")
+    collision.addObject('MeshObjLoader', name="loader",
+                        filename="mesh/smCube27.obj", triangulate=True)
+    collision.addObject('Mesh', src="@loader")
+    collision.addObject('MechanicalObject', src="@loader")
+    collision.addObject('TriangleCollisionModel', group="1")
+    collision.addObject('LineCollisionModel', group="1")
+    collision.addObject('PointCollisionModel', group="1")
+    collision.addObject('BarycentricMapping', input="@..", output="@.")
+
+
+def createScene(root):
+    root.gravity = [0, -10, 0]
+    createDragon(root, "Dragon", True, False)
+    createCube(root, "Cube", True, False)
+    return root

--- a/src/SofaPython3/DataHelper.cpp
+++ b/src/SofaPython3/DataHelper.cpp
@@ -383,9 +383,10 @@ py::object toPython(BaseData* d, bool writeable)
     {
         if(!writeable)
         {
-            getPythonArrayFor(d);
-            return getBindingDataFactoryInstance()->createObject("DataContainer", d);
+            // return a copy
+            return convertToPython(d);
         }
+        // return a pointer
         return getPythonArrayFor(d);
     }
     /// If this is not the case we return the converted datas (copy)

--- a/src/SofaPython3/DataHelper.h
+++ b/src/SofaPython3/DataHelper.h
@@ -59,7 +59,6 @@ public:
         while (it != end)
         {
             creator = (*it).second;
-            std::cout << it->first << std::endl;
             py::object object = creator->createInstance(arg);
             if (!object.is_none())
             {
@@ -69,7 +68,6 @@ public:
         }
         return py::none();
     }
-
 };
 
 BindingDataFactory* getBindingDataFactoryInstance();
@@ -111,6 +109,7 @@ py::buffer_info SOFAPYTHON3_API toBufferInfo(BaseData& m);
 py::object SOFAPYTHON3_API convertToPython(BaseData* d);
 
 py::object SOFAPYTHON3_API toPython(BaseData* d, bool writeable=false);
+py::object SOFAPYTHON3_API toPython(const BaseData* d);
 void SOFAPYTHON3_API copyFromListScalar(BaseData& d, const AbstractTypeInfo& nfo, const py::list& l);
 void SOFAPYTHON3_API fromPython(BaseData* d, const py::object& o);
 


### PR DESCRIPTION
Here's a some improvement to the Python Forcefields API:

**- addForce / addDForce / addKToMatrix take a dict containing the different factors** (k,b,m factors) available traditionally in the mechanical params. (if you have ever implemented a forcefield and needed more than those 3 params from mechanical params, plz tell me, I'll make a more complex binding for mparams maybe)
**- addKToMatrix can now be implemented in python:** To avoid complex bindings of MultiMatrixAccessors, The function has the following input parameters:
1. **mparams:** the mechanical params
2. **nNodes:** the number of nodes (mstate.positions.size)
3. **nDofs:** the number of dofs per node (Coord::total_size)
the python addKToMatrix function must return the forcefield's contribution to the K matrix in either of the two following forms:
    - A plain numpy matrix, with shape = (nNodes * nDofs, nNodes * nDofs, 1)
    - a numpy array of tuples (i, j, val) corresponding to the indices in the K matrix, & the value to set.
In both cases, the matrix offset traditionally retrieved from the multimatrixaccessor is ignored on the python side, and added to the indices in the bindings

The ForceField.py test file contains the construction of a scene with 2 objects (a cube and a dragon) using a basic RestShapeSpringsForcefield implemented in python.to keep them in place despite gravity & user interaction.
The scene is created 3 times: once using an explicit integration scheme (meaning only addForce will be called), once using an implicit scheme with an iterative solver (addForce & addDForce tested), and finally once using a direct solver (SparseLDL) and an euler implicit (addForce / addDForce / addKToMatrix)

**###LIMITATIONS:**

1. All the potentially useful params available in the C++ implementation might not be available in python (rayleigh stiffness, dt, energy, symmetricMatrix etc are currently not bound to python). It's not hard to do, just idk which of those are actually used in forcefields & I didn't want to implement a binding for everything either
2. nDofs can be used to determine which kind of DOFs we can work with in the forcefield, but it's a bit weird not to know whether we're manipulating rigids, vec3s or vec2 etc, especially in addKToMatrix. surveying some forcefield developers might be useful to know if we're going in the right direction.
3. The offset is not passed as a parameter because it seemed to me to be useless for the person implementing the addKToMatrix method. But maybe I'm wrong..? anyone has an opinion here?
