### PR TITLE
New bindings for base (redo of #42)

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -654,6 +654,8 @@ void moduleAddBase(py::module &m)
 
         BindingBase::SetAttr(self,s,value);
     });
+    base.def("getClassName",&Base::getClassName, sofapython3::doc::base::getClassName);
+    base.def("getTemplateName",&Base::getTemplateName, sofapython3::doc::base::getTemplateName);
 }
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base_doc.h
@@ -125,6 +125,15 @@ static auto getData =
         :type s: string
         :return: the first data found of this name
         )";
+
+static auto getClassName =
+        R"(
+        Get the name of the class of the Base.
+        )";
+static auto getTemplateName =
+        R"(
+        Get the name of the template of the Base.
+        )";
   
 static auto getDefinitionSourceFilePos="Returns the line number where the object is defined.";
 static auto getDefinitionSourceFileName="Returns the name of the file that contains the object definition.";

--- a/bindings/Sofa/tests/Core/Base.py
+++ b/bindings/Sofa/tests/Core/Base.py
@@ -63,6 +63,15 @@ class Test(unittest.TestCase):
         obj1.name = "I_Changed_Again"
         self.assertEqual(obj2.an_objectName2.value, "I_Changed_Again")
 
+    def test_getClassName(self):
+        root = Sofa.Core.Node("root")
+        self.assertEqual(root.getClassName(), "DAGNode")
+
+    def test_getTemplateName(self):
+        root = Sofa.Core.Node("root")
+        c = root.addObject("MechanicalObject", name="t")
+        self.assertEqual(c.getTemplateName(),"Vec3d")
+
     def test_addExistingDataAsParentOfNewData(self):
         # TODO(@marques-bruno)
         # do a test like this:


### PR DESCRIPTION
Add 2 bindings, now all the functions binded in SofaPython for Base should also be binded in SofaPython3. The two new binded functions have docstring documentation, and are tested.