### PR TITLE
New binding node

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CORE_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/PythonScriptEvent.h
     )
 
 set(TYPES_HEADER_FILES
@@ -59,6 +60,7 @@ set(CORE_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/PythonScriptEvent.cpp
     )
 
 set(TYPES_SOURCE_FILES

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -178,7 +178,6 @@ namespace sofapython3
 
     void Controller_Trampoline::handleEvent(Event* event)
     {
-
         if (!s_isDictCreated)
         {
             s_getEventDict.resize(sofa::core::objectmodel::Event::getEventTypeCount() + 1, nullptr);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -34,6 +34,7 @@ using sofa::core::objectmodel::KeyreleasedEvent;
 using sofa::core::objectmodel::MouseEvent;
 #include "sofa/core/objectmodel/ScriptEvent.h"
 using sofa::core::objectmodel::ScriptEvent;
+#include "PythonScriptEvent.h"
 
 PYBIND11_DECLARE_HOLDER_TYPE(Controller,
                              sofapython3::py_shared_ptr<Controller>, true)
@@ -143,6 +144,17 @@ namespace sofapython3
                             "sender"_a=py::cast(evt->getSender()),
                             "event_name"_a=evt->getEventName());
         };
+        e = new PythonScriptEvent(nullptr, "", nullptr);
+        eventDict[e->getEventTypeIndex()] = [] (Event* event) -> py::object {
+            auto evt = dynamic_cast<PythonScriptEvent*>(event);
+            return py::dict("type"_a=evt->getClassName(),
+                            "isHandled"_a=evt->isHandled(),
+                            "sender"_a=py::cast(evt->getSender()),
+                            "event_name"_a=evt->getEventName(),
+                            "userData"_a=evt->getUserData());
+        };
+
+
 
         // TODO: bind other events' attributes here
     }
@@ -166,6 +178,7 @@ namespace sofapython3
 
     void Controller_Trampoline::handleEvent(Event* event)
     {
+
         if (!s_isDictCreated)
         {
             s_getEventDict.resize(sofa::core::objectmodel::Event::getEventTypeCount() + 1, nullptr);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -32,7 +32,7 @@ using sofa::core::objectmodel::BaseObjectDescription;
 #include <sofa/core/objectmodel/Link.h>
 
 #include "Binding_Node_doc.h"
-#include <SofaPython3/Sofa/Core/PythonScriptEvent.h>
+#include "PythonScriptEvent.h"
 
 namespace sofapython3
 {
@@ -404,10 +404,10 @@ p.def("getMechanicalMapping", [](Node *self) ->py::object{
     }
     return py::none();
 }, sofapython3::doc::sofa::core::Node::getMechanicalMapping);
-p.def("sendMessage", [](Node* self, py::object* pyUserData, char* eventName){
+p.def("sendEvent", [](Node* self, py::object* pyUserData, char* eventName){
     sofapython3::PythonScriptEvent event(self, eventName, pyUserData);
     self->propagateEvent(sofa::core::ExecParams::defaultInstance(), &event);
-});
+}, sofapython3::doc::sofa::core::Node::sendEvent);
 
 }
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -32,6 +32,7 @@ using sofa::core::objectmodel::BaseObjectDescription;
 #include <sofa/core/objectmodel/Link.h>
 
 #include "Binding_Node_doc.h"
+#include <SofaPython3/Sofa/Core/PythonScriptEvent.h>
 
 namespace sofapython3
 {
@@ -194,6 +195,10 @@ py::object getItem(Node& self, std::list<std::string>& path)
     return py::cast(self); // should never get there
 }
 
+std::string getLink(Node* node){
+    return ("@"+node->getPathName()).c_str();
+}
+
 void moduleAddNode(py::module &m) {
     moduleAddBaseIterator(m);
 
@@ -278,10 +283,7 @@ void moduleAddNode(py::module &m) {
 
     p.def("getRoot", &Node::getRoot, sofapython3::doc::sofa::core::Node::getRoot);
     p.def("getPathName", &Node::getPathName, sofapython3::doc::sofa::core::Node::getPathName);
-    p.def("getLink", [](Node* node) {
-        return ("@"+node->getPathName()).c_str();
-    }, sofapython3::doc::sofa::core::Node::getLink);
-
+    p.def("getLink", &getLink, sofapython3::doc::sofa::core::Node::getLink);
     p.def_property_readonly("children", [](Node* node)
     {
         return new BaseIterator(node, [](Node* n) -> size_t { return n->child.size(); },
@@ -359,6 +361,52 @@ p.def("__getitem__", [](Node& self, const std::string& s) -> py::object
     // finally search for the object at the given path:
     return getItem(self, stringlist);
 
+});
+p.def("removeObject", &Node::removeObject, sofapython3::doc::sofa::core::Node::removeObject);
+p.def("getRootPath", &Node::getRootPath, sofapython3::doc::sofa::core::Node::getRootPath);
+p.def("moveChild", [](Node *self, BaseNode* child, BaseNode* prevParent){
+    if (child && prevParent){
+        self->moveChild(child, prevParent);
+        return;
+    }
+    throw py::value_error("Invalid arguments provided");
+}, sofapython3::doc::sofa::core::Node::moveChild);
+p.def("isInitialized", &Node::isInitialized, sofapython3::doc::sofa::core::Node::isInitialized);
+p.def("getAsACreateObjectParameter", [](Node *self){
+    return getLink(self);
+}, sofapython3::doc::sofa::core::Node::getAsACreateObjectParameter);
+p.def("detachFromGraph", &Node::detachFromGraph, sofapython3::doc::sofa::core::Node::detachFromGraph);
+p.def("getMass", [](Node *self) ->py::object {
+    sofa::core::behavior::BaseMass* mass = self->mass.get();
+    if (mass){
+        return PythonDownCast::toPython(mass);
+    }
+    return py::none();
+}, sofapython3::doc::sofa::core::Node::getMass);
+p.def("getForceField", [](Node *self, unsigned int index) ->py::object{
+    sofa::core::behavior::BaseForceField* ff = self->forceField.get(index);
+    if (ff){
+        return PythonDownCast::toPython(ff);
+    }
+    return py::none();
+}, sofapython3::doc::sofa::core::Node::getForceField);
+p.def("getMechanicalState", [](Node *self) -> py::object{
+    sofa::core::behavior::BaseMechanicalState* state = self->mechanicalState.get();
+    if (state){
+        return PythonDownCast::toPython(state);
+    }
+    return py::none();
+}, sofapython3::doc::sofa::core::Node::getMechanicalState);
+p.def("getMechanicalMapping", [](Node *self) ->py::object{
+    sofa::core::BaseMapping* mapping = self->mechanicalMapping.get();
+    if (mapping){
+        return PythonDownCast::toPython(mapping);
+    }
+    return py::none();
+}, sofapython3::doc::sofa::core::Node::getMechanicalMapping);
+p.def("sendMessage", [](Node* self, py::object* pyUserData, char* eventName){
+    sofapython3::PythonScriptEvent event(self, eventName, pyUserData);
+    self->propagateEvent(sofa::core::ExecParams::defaultInstance(), &event);
 });
 
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
@@ -248,6 +248,73 @@ static auto objects =
         >>> for object in n.objects:
         >>>     print(object.name)
         )";
+static auto removeObject =
+        R"(
+        Remove an object
+        :param object: the object to be removed
+        :type object: BaseObject
+        )";
+
+static auto getRootPath =
+        R"(
+        Return the path from this node to the root node
+        )";
+
+static auto moveChild =
+        R"(
+        Move a node from another node.
+        :param child: the node to be moved
+        :param prevParent: the previous parent of the node to be moved
+        :type child: Sofa.Simulation.Node
+        :type prevParent: Sofa.Simulation.Node
+        )";
+
+static auto isInitialized =
+        R"(
+        Checks if the node has been initialized
+        :return: true if it has been initialized
+        )";
+static auto getAsACreateObjectParameter =
+        R"(
+        Get the link of the current node
+        :rtype: string
+        )";
+
+static auto detachFromGraph =
+        R"(
+        Remove the current node from the graph: depending on the type of Node, it can have one or several parents.
+        )";
+
+static auto getMass =
+        R"(
+        Get the mass of the node
+        )";
+static auto getForceField =
+        R"(
+        Get the force field of a node, given an index.
+        :param index: index of the force field
+        :type index: unsigned int.
+        )";
+
+static auto getMechanicalState =
+        R"(
+        Get the mechanical state of the node.
+        )";
+
+static auto getMechanicalMapping =
+        R"(
+        Get the mechanical mapping of the node.
+        )";
+static auto sendMessage =
+        R"(
+        Send an event to other nodes,
+        by creating a PythonScriptEvent and propagating it to the rest of the tree.
+        Only the nodes and objects downstream will receive the message.
+        :param pyUserData: the user data that can be sent
+        :param eventName: the name of the event
+        :type pyUserData: py::object
+        :type eventName: string
+        )";
 
 }
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
@@ -305,7 +305,7 @@ static auto getMechanicalMapping =
         R"(
         Get the mechanical mapping of the node.
         )";
-static auto sendMessage =
+static auto sendEvent =
         R"(
         Send an event to other nodes,
         by creating a PythonScriptEvent and propagating it to the rest of the tree.

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.cpp
@@ -1,0 +1,11 @@
+#include "PythonScriptEvent.h"
+
+
+namespace sofapython3 {
+
+
+PythonScriptEvent::PythonScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName, py::object* userData)
+    : sofa::core::objectmodel::ScriptEvent(sender,eventName)
+    , m_userData(userData){}
+PythonScriptEvent::~PythonScriptEvent(){}
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.cpp
@@ -1,8 +1,6 @@
 #include "PythonScriptEvent.h"
 
-
 namespace sofapython3 {
-
 
 PythonScriptEvent::PythonScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName, py::object* userData)
     : sofa::core::objectmodel::ScriptEvent(sender,eventName)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.h
@@ -7,20 +7,16 @@ namespace sofapython3
 {
 namespace py { using namespace pybind11; }
 
-
 class PythonScriptEvent : public sofa::core::objectmodel::ScriptEvent
 {
 public:
     PythonScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName, py::object* userData=NULL);
-
     ~PythonScriptEvent() override;
     py::object* getUserData() const {return m_userData;}
     const char* getClassName() const override { return "PythonScriptEvent"; }
 
 private:
-
     py::object* m_userData;
-
 };
 
 } // namespace objectmodel

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/PythonScriptEvent.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <sofa/core/objectmodel/ScriptEvent.h>
+
+namespace sofapython3
+{
+namespace py { using namespace pybind11; }
+
+
+class PythonScriptEvent : public sofa::core::objectmodel::ScriptEvent
+{
+public:
+    PythonScriptEvent(sofa::simulation::Node::SPtr sender, const char* eventName, py::object* userData=NULL);
+
+    ~PythonScriptEvent() override;
+    py::object* getUserData() const {return m_userData;}
+    const char* getClassName() const override { return "PythonScriptEvent"; }
+
+private:
+
+    py::object* m_userData;
+
+};
+
+} // namespace objectmodel
+

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -7,7 +7,7 @@ import Sofa.Simulation
 class MyController(Sofa.Core.Controller):
         """This is my custom controller
            when init is called from Sofa this should call the python init function
-           This controller is used to test the method sendMessage
+           This controller is used to test the method sendEvent
         """
         def __init__(self, *args, **kwargs):
             ## These are needed (and the normal way to override from a python class)
@@ -241,26 +241,11 @@ class Test(unittest.TestCase):
             mm  = root.addObject("BarycentricMapping", input="@/t1", output="@/t2")
             self.assertEqual(mm, root.getMechanicalMapping())
 
-        def test_sendMessage(self):
+        def test_sendEvent(self):
             root = Sofa.Core.Node("rootNode")
             node = root.addChild("node")
             c = node.addObject(MyController(name="controller"))
-            root.sendMessage(root.getName(),"This is a test")
+            root.sendEvent(root.getName(),"This is a test")
             self.assertEqual(c.event_name, "This is a test")
             self.assertEqual(c.userData, root.getName())
             self.assertEqual(c.sender, root)
-
-
-def getTestsName():
-    suite = unittest.TestLoader().loadTestsFromTestCase(Test)
-    return [ test.id().split(".")[2] for test in suite]
-
-def runTests():
-        import sys
-        suite = None
-        if( len(sys.argv) == 1 ):
-            suite = unittest.TestLoader().loadTestsFromTestCase(Test)
-        else:
-            suite = unittest.TestSuite()
-            suite.addTest(Test(sys.argv[1]))
-        return unittest.TextTestRunner(verbosity=1).run(suite).wasSuccessful()


### PR DESCRIPTION
New functions binded in SofaPython for Node are now also binded in SofaPython3. The functions present in SofaPython that weren't binded in SofaPython3 are functions whose existence is questionnable, because they expose parts of Sofa that shouldn't be exposed to the user.
Every function has docstring documentation, and the bindings are tested.
A new class was created : PythonScriptEvent, that is used in the binded function sendMessage. The goal of sendMessage is to send an event, and to put additionnal data (called here userData). 
Two options were possible to implement this : 

1.  Create a class PythonSriptEvent, that inherits from ScriptEvent, and has one more attribute : an pyObject userData, used to transmit the additionnal data.
2. Move the class ScriptEvent, that appears to only be used in SofaPython, to SofaPython3 and modify it to add the userData attribute.

Here, I made the choice to go with option 1, because it seemed simpler to only modify code in the plugin SofaPython3, rather than Sofa itself. What do you think @damienmarchal ?