### PR TITLE
FIX: bad size for python conversions on vectors (wip)

### DIFF
--- a/src/SofaPython3/DataHelper.cpp
+++ b/src/SofaPython3/DataHelper.cpp
@@ -405,7 +405,6 @@ py::object toPython(BaseData* d, bool writeable)
     {
         if(!writeable)
         {
-            return getPythonArrayFor(d);
             getPythonArrayFor(d);
             return getBindingDataFactoryInstance()->createObject("DataContainer", d);
         }

--- a/src/SofaPython3/DataHelper.cpp
+++ b/src/SofaPython3/DataHelper.cpp
@@ -403,19 +403,17 @@ py::object toPython(BaseData* d, bool writeable)
     /// we can expose the field as a numpy.array (no copy)
     if(nfo.Container() && nfo.SimpleLayout())
     {
-        if(writeable)
+        if(!writeable)
+        {
             return getPythonArrayFor(d);
+            getPythonArrayFor(d);
+            return getBindingDataFactoryInstance()->createObject("DataContainer", d);
+        }
+        return getPythonArrayFor(d);
     }
     /// If this is not the case we return the converted datas (copy)
     return convertToPython(d);
 }
-
-// const implementation. always returning readonly objects
-py::object toPython(const BaseData* d)
-{
-    return convertToPython(const_cast<BaseData*>(d));
-}
-
 
 void copyFromListScalar(BaseData& d, const AbstractTypeInfo& nfo, const py::list& l)
 {

--- a/src/SofaPython3/DataHelper.cpp
+++ b/src/SofaPython3/DataHelper.cpp
@@ -413,15 +413,6 @@ py::object toPython(BaseData* d, bool writeable)
 // const implementation. always returning readonly objects
 py::object toPython(const BaseData* d)
 {
-    const AbstractTypeInfo& nfo{ *(d->getValueTypeInfo()) };
-    /// In case the data is a container with a simple layout
-    /// we can expose the field as a numpy.array (no copy)
-    if(nfo.Container() && nfo.SimpleLayout())
-    {
-        getPythonArrayFor(const_cast<BaseData*>(d));
-        return getBindingDataFactoryInstance()->createObject("DataContainer", const_cast<BaseData*>(d));
-    }
-    /// If this is not the case we return the converted datas (copy)
     return convertToPython(const_cast<BaseData*>(d));
 }
 

--- a/src/SofaPython3/DataHelper.h
+++ b/src/SofaPython3/DataHelper.h
@@ -109,6 +109,7 @@ py::buffer_info SOFAPYTHON3_API toBufferInfo(BaseData& m);
 py::object SOFAPYTHON3_API convertToPython(BaseData* d);
 
 py::object SOFAPYTHON3_API toPython(BaseData* d, bool writeable=false);
+py::object SOFAPYTHON3_API toPython(const BaseData* d);
 void SOFAPYTHON3_API copyFromListScalar(BaseData& d, const AbstractTypeInfo& nfo, const py::list& l);
 void SOFAPYTHON3_API fromPython(BaseData* d, const py::object& o);
 


### PR DESCRIPTION
- Adding a toPython function for const BaseData* to avoid const_casting in the code
- myData.value -> returns a python array instead of a DataContainer
- Fix copyFromListScalar for containers with elements of type Integer
- (failed) attempt to fix setSize() in copyFromListScalar