### PR TITLE
[SofaRuntime] Adds the ability to get the timer's records.

### DIFF
--- a/bindings/SofaRuntime/CMakeLists.txt
+++ b/bindings/SofaRuntime/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCE_FILES
     )
 set(HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SofaRuntime/Input/Submodule_Input.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/SofaRuntime/Input/Submodule_Input_doc.h
     )

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer.cpp
@@ -2,11 +2,129 @@
 using sofa::helper::AdvancedTimer;
 
 #include "Submodule_Timer.h"
-
+#include "Submodule_Timer_doc.h"
 
 
 namespace sofapython3
 {
+
+py::dict getRecords(const std::string & id) {
+    using sofa::helper::Record;
+    using sofa::helper::system::thread::ctime_t;
+    using sofa::helper::system::thread::CTime;
+
+    static auto timer_freq = CTime::getTicksPerSec();
+    auto getTime = [](ctime_t t) {
+        return 1000.0 * t / timer_freq;
+    };
+
+    const auto records = AdvancedTimer::getRecords(id);
+
+    std::stack<py::dict> tokens;
+    py::dict token, token_temp;
+    tokens.push(token);
+    ctime_t t0;
+    std::string name;
+
+    for (const auto & r : records) {
+        switch (r.type) {
+            case Record::RNONE:
+                break;
+            case Record::RBEGIN: // Timer begins
+                token = tokens.top();
+                name = (std::string) AdvancedTimer::IdTimer(r.id);
+                if (token.contains(name.c_str())) {
+                    if (py::list::check_(token[name.c_str()])) {
+                        token_temp = py::dict();
+                        py::list(token[name.c_str()]).append(token_temp);
+                        token = token_temp;
+                    } else if (py::dict::check_(token[name.c_str()])) {
+                        token_temp = token[name.c_str()];
+                        token[name.c_str()] = py::list();
+                        py::list(token[name.c_str()]).append(token_temp);
+                        token_temp = py::dict();
+                        py::list(token[name.c_str()]).append(token_temp);
+                        token = token_temp;
+                    } else {
+                        msg_error("Timer::getRecords") << "Got an unexpected token of type '" << std::string(py::str(token.get_type())) << "'.";
+                        break;
+                    }
+                } else {
+                    token[name.c_str()] = py::dict();
+                    token = token[name.c_str()];
+                }
+                t0 = r.time;
+                token["start_time"] = getTime(r.time - t0);
+                tokens.push(token);
+                break;
+            case Record::REND: // Timer ends
+                token = tokens.top();
+                token["end_time"] = getTime(r.time - t0);
+                token["total_time"] = getTime(r.time - t0) - py::cast<float>(token["start_time"]);
+                tokens.pop();
+                break;
+            case Record::RSTEP_BEGIN: // Step begins
+                token = tokens.top();
+                name = (std::string) AdvancedTimer::IdStep(r.id);
+                if (token.contains(name.c_str())) {
+                    if (py::list::check_(token[name.c_str()])) {
+                        token_temp = py::dict();
+                        py::list(token[name.c_str()]).append(token_temp);
+                        token = token_temp;
+                    } else if (py::dict::check_(token[name.c_str()])) {
+                        token_temp = token[name.c_str()];
+                        token[name.c_str()] = py::list();
+                        py::list(token[name.c_str()]).append(token_temp);
+                        token_temp = py::dict();
+                        py::list(token[name.c_str()]).append(token_temp);
+                        token = token_temp;
+                    } else {
+                        msg_error("Timer::getRecords") << "Got an unexpected token of type '" << std::string(py::str(token.get_type())) << "'.";
+                        break;
+                    }
+                } else {
+                    token[name.c_str()] = py::dict();
+                    token = token[name.c_str()];
+                }
+                token["start_time"] = getTime(r.time - t0);
+                tokens.push(token);
+                break;
+            case Record::RSTEP_END: // Step ends
+                token = tokens.top();
+                token["end_time"] = getTime(r.time - t0);
+                token["total_time"] = getTime(r.time - t0) - py::cast<float>(token["start_time"]);
+                tokens.pop();
+                break;
+            case Record::RVAL_SET: // Sets a value
+                token = tokens.top();
+                name = (std::string) AdvancedTimer::IdVal(r.id);
+                token[name.c_str()] = r.val;
+                break;
+            case Record::RVAL_ADD: // Sets a value
+                token = tokens.top();
+                name = (std::string) AdvancedTimer::IdVal(r.id);
+                token[name.c_str()] = r.val;
+                break;
+            default:
+                name = (std::string) AdvancedTimer::IdObj(r.id);
+                token = tokens.top();
+                token[name.c_str()] = py::list();
+                token = token[name.c_str()];
+                token["start_time"] = r.time;
+                break;
+        }
+    }
+
+    // Pop the last token ("records")
+    token = tokens.top();
+    tokens.pop();
+
+    // The stack should be empty by now
+    if (!tokens.empty())
+        msg_error("Timer::getRecords") << "Records stack leaked.";
+
+    return token;
+}
 
 py::module addSubmoduleTimer(py::module &m)
 {
@@ -21,24 +139,19 @@ py::module addSubmoduleTimer(py::module &m)
            Not so advanced for now, but it will be...
        )doc";
 
-    timer.def("clear", AdvancedTimer::clear, "Clears the AdvancedTimer");
-
-    timer.def("isEnabled", &AdvancedTimer::isEnabled, py::arg("id"),
-              "Returns True if the given id is enabled, False otherwise");
-    timer.def("setEnabled", &AdvancedTimer::setEnabled, py::arg("id"), py::arg("enabled"),
-              "enables or disables the given timer");
-
-    timer.def("getInterval", &AdvancedTimer::getInterval, py::arg("id"), "returns the Timer's interval");
-    timer.def("setInterval", &AdvancedTimer::setInterval, py::arg("id"), py::arg("interval"),
-              "sets the interval for the given timer");
+    timer.def("clear", AdvancedTimer::clear, doc::Timer::clear);
+    timer.def("isEnabled", [](const std::string & name) {AdvancedTimer::isEnabled(name);}, py::arg("id"), doc::Timer::isEnabled);
+    timer.def("setEnabled", [](const std::string & n, bool e) {AdvancedTimer::setEnabled(n, e);}, py::arg("name"), py::arg("enabled"), doc::Timer::setEnabled);
+    timer.def("getInterval", &AdvancedTimer::getInterval, py::arg("id"), doc::Timer::getInterval);
+    timer.def("setInterval", &AdvancedTimer::setInterval, py::arg("id"), py::arg("interval"), doc::Timer::setInterval);
 
     timer.def("begin", [](const std::string& id){ AdvancedTimer::begin(id);}, py::arg("id"));
     timer.def("stepBegin", [](const std::string& id){ AdvancedTimer::stepBegin(id);}, py::arg("id"));
     timer.def("stepEnd", [](const std::string& id){ AdvancedTimer::stepEnd(id);}, py::arg("id"));
     timer.def("end", [](const std::string& id){ AdvancedTimer::end(id);}, py::arg("id"));
 
-    timer.def("setOutputType", &AdvancedTimer::setOutputType, py::arg("id"), py::arg("newOutputType"),
-              "Changes the output type for a given timer");
+    timer.def("setOutputType", &AdvancedTimer::setOutputType, py::arg("id"), py::arg("newOutputType"), doc::Timer::setOutputType);
+    timer.def("getRecords", &getRecords, py::arg("id"));
 
     return timer;
 }

--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer_doc.h
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Timer/Submodule_Timer_doc.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace sofapython3::doc::Timer
+{
+static auto clear =
+R"(
+Clears the AdvancedTimer.
+)";
+
+static auto isEnabled =
+R"(
+Returns True if the given id is enabled, False otherwise.
+)";
+
+static auto setEnabled =
+R"(
+Enables or disables the given timer.
+)";
+
+static auto getInterval =
+R"(
+Returns the Timer's interval.
+)";
+
+static auto setInterval =
+R"(
+Sets the interval for the given timer.
+)";
+
+static auto setOutputType =
+R"(
+Changes the output type for a given timer.
+)";
+}


### PR DESCRIPTION
Currently, we can only get timer's "records" by getting the JSON output from the `Timer.End(id,node)` function. Unfortunately, this output does not allow for a lot of flexibility, as it already has parsed the records and only gives the "statistical data" (avg, max, min..) from the last `x` intervals, set from the `Timer.setInterval` function. It also doesn't give the Timer's data variables.

This PR allows one to directly get the Timer's records and do whatever he wants with it. It is then possible to do something like:

```python
import SofaRuntime
import Sofa.Core

root = Sofa.Core.Node("root")

# Creates the scene here...
createScene(root)

# Launch the simulation
for step_id in range(0, 20):
  # Start the timer
  SofaRuntime.Timer.begin("MyCoolTimer")

  # Do one step
  Sofa.Simulation.animate(root)

  # Get the records
  records = SofaRuntime.Timer.getRecords("MyCoolTimer")

  # Step timings
  addForce = records['Simulation::animate']['AnimateVisitor']['Mechanical']['ComputeForce']['total_time']
  MBKBuild = records['Simulation::animate']['AnimateVisitor']['Mechanical']['MBKBuild']['total_time']
  MBKSolve = records['Simulation::animate']['AnimateVisitor']['Mechanical']['MBKSolve']['total_time']

  # Step datas
  nb_iterations = records['Simulation::animate']['AnimateVisitor']['Mechanical']['MBKSolve']['StaticSolver::Solve']['nb_iterations']
  residual = records['Simulation::animate']['AnimateVisitor']['Mechanical']['MBKSolve']['StaticSolver::Solve']['residual']

  # End the timer
  SofaRuntime.Timer.end("MyCoolTimer")
```

Very useful for analyzing our algos and automatically plot timing and convergence graphs ...