### PR TITLE
[SofaPython3] Add Data/Binding_DataVectorString.*

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -25,6 +25,8 @@ set(CORE_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataString.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataString_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/PythonScriptEvent.h
     )
@@ -60,6 +62,7 @@ set(CORE_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataString.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
@@ -4,12 +4,6 @@
 
 #include <sofa/core/behavior/BaseForceField.h>
 
-
-//template class pybind11::class_<
-//                          sofa::core::behavior::BaseForceField,
-//                          sofa::core::objectmodel::BaseObject,
-//                          sofa::core::sptr<sofa::core::behavior::BaseForceField>>;
-
 namespace sofapython3
 {
 using sofa::core::behavior::BaseForceField;

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.cpp
@@ -82,7 +82,7 @@ void moduleAddDataContainer(py::module& m)
     p.def("__str__", [](BaseData* self)
     {
         std::stringstream tmp;
-        tmp << "Sofa.Core.DataContainer <'" << self->getName() << "', " << self << ">";
+        tmp << "Sofa.Core.DataContainer <name='" << self->getName() << "', address=" << self << ">";
         return py::str(tmp.str());
     });
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataString.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataString.cpp
@@ -19,6 +19,38 @@ using  sofa::core::objectmodel::BaseNode;
 namespace sofapython3
 {
 
+py::str DataString::__str__()
+{
+    std::stringstream s;
+    s << "Sofa.Core.DataString<name='" << getName()
+                        << "', value='" << getValueString()
+                        << "', address='"<< (void*)this <<"'>";
+    return s.str();
+}
+
+py::str DataString::__repr__()
+{
+    return py::repr(convertToPython(this));
+}
+
+py::bool_ DataString::__eq__(BaseData* other)
+{
+    if( this == other )
+        return true;
+    return false;
+}
+
+py::size_t DataString::__len__()
+{
+    return getValueString().size();
+}
+
+py::object DataString::__getitem__(const py::size_t index)
+{
+    auto nfo = getValueTypeInfo();
+    return py::str(&nfo->getTextValue(getValueVoidPtr(),0).at(index),1);
+}
+
 void moduleAddDataString(py::module& m)
 {
     py::class_<DataString, BaseData, raw_ptr<DataString>> s(m, "DataString");
@@ -26,11 +58,11 @@ void moduleAddDataString(py::module& m)
     getBindingDataFactoryInstance()->registerCreator(
                 "DataString", new TypeCreator<DataString*>());
 
-    s.def("__getitem__", [](BaseData& self, py::size_t index) -> py::object
-    {
-        auto nfo = self.getValueTypeInfo();
-        return py::str(&nfo->getTextValue(self.getValueVoidPtr(),0).at(index),1);
-    });
+    s.def("__eq__", &DataString::__eq__);
+    s.def("__len__", &DataString::__len__);
+    s.def("__getitem__",&DataString::__getitem__);
+    s.def("__repr__",&DataString::__repr__);
+    s.def("__str__", &DataString::__str__);
 }
 
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.cpp
@@ -1,0 +1,60 @@
+#include <sofa/defaulttype/DataTypeInfo.h>
+using sofa::defaulttype::AbstractTypeInfo;
+
+#include <sofa/core/objectmodel/BaseData.h>
+using sofa::core::objectmodel::BaseData;
+
+#include <sofa/core/objectmodel/BaseObject.h>
+using  sofa::core::objectmodel::BaseObject;
+
+#include <sofa/core/objectmodel/BaseNode.h>
+using  sofa::core::objectmodel::BaseNode;
+
+#include <SofaPython3/DataHelper.h>
+#include "../Binding_Base.h"
+#include "../Binding_BaseData.h"
+#include "Binding_DataVectorString.h"
+#include "Binding_DataVectorString_doc.h"
+
+namespace sofapython3
+{
+
+py::str DataVectorString::__str__()
+{
+    std::stringstream s;
+    s << "Sofa.Core.DataVectorString<name='" << getName()
+                        << "', value='" << getValueString()
+                        << "', address='"<< (void*)this <<"'>";
+    return s.str();
+}
+
+py::str DataVectorString::__repr__()
+{
+    return py::repr(convertToPython(this));
+}
+
+py::size_t DataVectorString::__len__()
+{
+    return getValueTypeInfo()->size(getValueVoidPtr());
+}
+
+py::object DataVectorString::__getitem__(const py::size_t index)
+{
+    auto nfo = getValueTypeInfo();
+    return py::str(nfo->getTextValue(getValueVoidPtr(),index));
+}
+
+void moduleAddDataVectorString(py::module& m)
+{
+    py::class_<DataVectorString, BaseData, raw_ptr<DataVectorString>> s(m, "DataVectorString");
+
+    getBindingDataFactoryInstance()->registerCreator(
+                "DataVectorString", new TypeCreator<DataVectorString*>());
+
+    s.def("__len__", &DataVectorString::__len__);
+    s.def("__getitem__",&DataVectorString::__getitem__);
+    s.def("__repr__",&DataVectorString::__repr__);
+    s.def("__str__", &DataVectorString::__str__);
+}
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.h
@@ -9,14 +9,13 @@ namespace sofapython3
 namespace py { using namespace pybind11; }
 using sofa::core::objectmodel::BaseData;
 
-void moduleAddDataString(py::module& m);
+void moduleAddDataVectorString(py::module& m);
 
-class DataString : public BaseData
+class DataVectorString : public BaseData
 {
 public:
     py::str __str__();
     py::str __repr__();
-    py::bool_ __eq__(BaseData* other);
     py::size_t __len__();
     py::object __getitem__(const py::size_t index);
 };

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString_doc.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace sofapython3::doc::datavectorstring
+{
+}  // namespace sofapython3::doc::datacontainer

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -14,6 +14,7 @@
 #include "Binding_Simulation.h"
 
 #include "Data/Binding_DataString.h"
+#include "Data/Binding_DataVectorString.h"
 #include "Data/Binding_DataContainer.h"
 
 #include "Submodule_Core.h"
@@ -58,6 +59,7 @@ PYBIND11_MODULE(Core, core)
                Sofa.Core.DataDictIterator
                Sofa.Core.DataContainer
                Sofa.Core.DataString
+               Sofa.Core.DataVectorString
                Sofa.Core.WriteAccessor
        )doc";
 
@@ -68,6 +70,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddWriteAccessor(core);
     moduleAddDataContainer(core);
     moduleAddDataString(core);
+    moduleAddDataVectorString(core);
     moduleAddBaseObject(core);
     moduleAddBaseCamera(core);
     moduleAddController(core);

--- a/bindings/Sofa/tests/Core/BaseData.py
+++ b/bindings/Sofa/tests/Core/BaseData.py
@@ -289,6 +289,12 @@ class Test(unittest.TestCase):
             self.assertEqual(wa[2, 2], 8.0)
             numpy.testing.assert_array_equal(wa, v*4.0)
 
+    def test_DataString(self):
+        n = Sofa.Core.Node("rootNode")
+        self.assertTrue(isinstance(n.name, Sofa.Core.DataString))
+        self.assertEqual(n.name.value, "rootNode")
+        self.assertEqual(len(n.name), 8)
+
     def test_DataAsContainerNumpyArray(self):
         n = Sofa.Core.Node("rootNode")
         c = n.addObject(NpArrayTestController(name="c"))

--- a/src/SofaPython3/DataHelper.cpp
+++ b/src/SofaPython3/DataHelper.cpp
@@ -418,6 +418,14 @@ py::object dataToPython(BaseData* d)
     {
         return getBindingDataFactoryInstance()->createObject("DataContainer", d);
     }
+    if(nfo.Container() && nfo.Text())
+    {
+        return getBindingDataFactoryInstance()->createObject("DataVectorString", d);
+    }
+    if(nfo.Text())
+    {
+        return getBindingDataFactoryInstance()->createObject("DataString", d);
+    }
 
     return py::cast(d);
 }


### PR DESCRIPTION
This is needed to expose in python the Data< vector<std::string> >.
There is still some bug in calculation of the length and thus the
corresponding test is failling.

Feel free to fix that.