### PR TITLE
Fix breaking changes from Sofa pull request 992 

### DIFF
--- a/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/src/SofaPython3/SceneLoaderPY3.cpp
@@ -73,10 +73,11 @@ void SceneLoaderPY3::getExtensionList(ExtensionList* list)
     list->push_back("py");
 }
 
-sofa::simulation::Node::SPtr SceneLoaderPY3::doLoad(const char *filename)
+sofa::simulation::Node::SPtr SceneLoaderPY3::doLoad(const std::string& filename, const std::vector<std::string>& /*sceneArgs*/)
 {
     sofa::simulation::Node::SPtr root = sofa::simulation::Node::create("root");
-    loadSceneWithArguments(filename, sofa::helper::ArgumentParser::extra_args(), root);
+    std::cout << "\n'"<< filename.c_str()<<"'\n"<< std::endl;
+    loadSceneWithArguments(filename.c_str(), sofa::helper::ArgumentParser::extra_args(), root);
     return root;
 }
 

--- a/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/src/SofaPython3/SceneLoaderPY3.cpp
@@ -76,7 +76,6 @@ void SceneLoaderPY3::getExtensionList(ExtensionList* list)
 sofa::simulation::Node::SPtr SceneLoaderPY3::doLoad(const std::string& filename, const std::vector<std::string>& /*sceneArgs*/)
 {
     sofa::simulation::Node::SPtr root = sofa::simulation::Node::create("root");
-    std::cout << "\n'"<< filename.c_str()<<"'\n"<< std::endl;
     loadSceneWithArguments(filename.c_str(), sofa::helper::ArgumentParser::extra_args(), root);
     return root;
 }

--- a/src/SofaPython3/SceneLoaderPY3.h
+++ b/src/SofaPython3/SceneLoaderPY3.h
@@ -48,7 +48,7 @@ public:
     virtual bool canWriteFileExtension(const char *extension) override;
 
     /// load the file
-    virtual Node::SPtr doLoad(const char *filename) override;
+    virtual Node::SPtr doLoad(const std::string& filename, const std::vector<std::string>& sceneArgs=std::vector<std::string>(0)) override;
 
     void loadSceneWithArguments(const char *filename,
                                 const std::vector<std::string>& arguments=std::vector<std::string>(0),


### PR DESCRIPTION
The pull request 992 changed the signature of onLoad of the class SceneLoader, that SceneLoaderPY3 inherits from, breaking the class.