### PR TITLE
WIP: bindings for Visitors

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -33,6 +33,7 @@ using sofa::core::objectmodel::BaseObjectDescription;
 
 #include "Binding_Node_doc.h"
 #include "Binding_PythonScriptEvent.h"
+#include "Binding_Visitor.h"
 
 namespace sofapython3
 {
@@ -397,6 +398,13 @@ void sendEvent(Node* self, py::object pyUserData, char* eventName)
     self->propagateEvent(sofa::core::ExecParams::defaultInstance(), &event);
 }
 
+
+void execute(Node* self, sofa::simulation::Visitor* visitor)
+{
+    self->execute(visitor);
+}
+
+
 void moduleAddNode(py::module &m) {
     moduleAddBaseIterator(m);
 
@@ -441,6 +449,6 @@ void moduleAddNode(py::module &m) {
     p.def("getMechanicalState", &getMechanicalState, sofapython3::doc::sofa::core::Node::getMechanicalState);
     p.def("getMechanicalMapping", &getMechanicalMapping, sofapython3::doc::sofa::core::Node::getMechanicalMapping);
     p.def("sendEvent", &sendEvent, sofapython3::doc::sofa::core::Node::sendEvent);
-
+    p.def("execute", &execute, sofapython3::doc::sofa::core::Node::execute);
 }
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
@@ -314,6 +314,14 @@ static auto sendEvent =
         :type eventName: string
         )";
 
+static auto execute =
+        R"(
+        Executes a visitor over the given node.
+        The visitor will process each subnode in the scene graph from the node "self"
+        :param self: the node on which to execute the visitor
+        :param visitor: a visitor
+        )";
+
 }
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
@@ -1,0 +1,151 @@
+#include "Binding_Visitor.h"
+
+#include "Binding_Node.h"
+
+#include <sofa/simulation/PropagateEventVisitor.h>
+
+#include <SofaPython3/DataHelper.h>
+#include <SofaPython3/PythonFactory.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/detail/init.h>
+
+PYBIND11_DECLARE_HOLDER_TYPE(Visitor,
+                             sofapython3::py_non_intrusive_ptr<Visitor>, true)
+
+
+namespace sofapython3
+{
+    namespace py { using namespace pybind11; }
+    using namespace pybind11::literals;
+    using sofa::simulation::Visitor;
+
+
+    class Visitor_Trampoline : public Visitor, public PythonNonIntrusiveTrampoline
+    {
+    public:
+        Visitor_Trampoline(sofa::core::ExecParams* params = sofa::core::ExecParams::defaultInstance())
+            : Visitor(params)
+        {
+            // @damienmarchal: Why don't we need this in every other trampoline? Why did I miss?
+            setInstance(py::cast(dynamic_cast<PythonNonIntrusiveTrampoline*>(this)));
+        }
+
+        ~Visitor_Trampoline() override = default; // impossible to destroy pyobject as it's a circular dependency..
+
+        sofa::simulation::Visitor::Result processNodeTopDown(sofa::simulation::Node* node) override
+        {
+            PYBIND11_OVERLOAD_PURE(Visitor::Result, Visitor, processNodeBottomUp, node);
+        }
+
+        void processNodeBottomUp(sofa::simulation::Node* node) override
+        {
+            try {
+                PYBIND11_OVERLOAD_PURE(void, Visitor, processNodeBottomUp, node);
+            } catch (std::exception & /*e*/) {
+                return;
+            }
+        }
+
+        const char* getClassName() const override
+        {
+            return pyobject->ob_type->tp_name;
+        }
+        const char* getCategoryName() const override
+        {
+            try {
+                PYBIND11_OVERLOAD_PURE(const char*, Visitor, getCategoryName);
+            } catch (std::exception& /*e*/) {
+                return Visitor::getCategoryName();
+            }
+        }
+        bool isThreadSafe() const override {
+            try {
+                PYBIND11_OVERLOAD_PURE(bool, Visitor, isThreadSafe);
+            } catch (std::exception& /*e*/) {
+                return Visitor::isThreadSafe();
+            }
+        }
+    };
+
+    class ExecuteFunctionVisitor: public Visitor
+    {
+    public:
+        ExecuteFunctionVisitor(py::object function)
+            : Visitor(sofa::core::ExecParams::defaultInstance())
+            , m_func(function)
+        {
+
+        }
+
+        virtual Result processNodeTopDown(sofa::simulation::Node* node) override
+        {
+            py::object pyr = m_func(node);
+            if (pyr.is_none())
+                throw py::value_error("ExecuteFunctionVisitor's signature must be (arg0: Sofa.Core.Node) -> bool");
+
+            if (py::cast<bool>(pyr))
+                return RESULT_CONTINUE;
+            return RESULT_PRUNE;
+        }
+
+        const char* getClassName() const override
+        {
+            return "ExecuteFunctionVisitor";
+        }
+        const char* getCategoryName() const override
+        {
+            return "Default";
+        }
+        bool isThreadSafe() const override
+        {
+            return false;
+        }
+    private:
+        py::object m_func;
+    };
+
+    void moduleAddVisitor(py::module &m)
+    {
+
+        py::class_<Visitor, Visitor_Trampoline,
+                py_non_intrusive_ptr<Visitor>> v(m, "Visitor",
+                                                 py::dynamic_attr(),
+                                                 py::multiple_inheritance());
+
+        v.def(py::init([]()
+        {
+            return new Visitor_Trampoline(sofa::core::ExecParams::defaultInstance());
+        }));
+
+        py::enum_<Visitor::TreeTraversalRepetition>(v, "TreeTraversalRepetition", py::arithmetic(), "")
+                .value("NO_REPETITION", Visitor::NO_REPETITION, "")
+                .value("REPEAT_ALL", Visitor::REPEAT_ALL, "")
+                .value("REPEAT_ONCE", Visitor::REPEAT_ONCE, "")
+                .export_values();
+
+        py::enum_<Visitor::Result>(v, "Result", py::arithmetic(), "")
+                .value("RESULT_CONTINUE", Visitor::RESULT_CONTINUE, "")
+                .value("RESULT_PRUNE", Visitor::RESULT_PRUNE, "")
+                .export_values();
+
+        v.def("execute", [](Visitor& self, Node& node, bool precomputedOrder = false){ self.execute(node.toBaseContext(), precomputedOrder); });
+        v.def("processNodeTopDown", [](Visitor& self, Node* node) { self.processNodeTopDown(node); }, "node"_a);
+        v.def("processNodeBottomUp", [](Visitor& self, Node* node) { self.processNodeBottomUp(node); }, "node"_a);
+        v.def("childOrderReversed", &Visitor::childOrderReversed, "node"_a);
+        v.def("isThreadSafe", &Visitor::isThreadSafe);
+        v.def("getCategoryName", &Visitor::getCategoryName);
+        v.def("getClassName", &Visitor::getClassName);
+        v.def("getInfos", &Visitor::getInfos);
+        v.def("treeTraversal", &Visitor::treeTraversal, "repeat"_a);
+        v.def("execParams", &Visitor::execParams);
+
+        py::class_<ExecuteFunctionVisitor, Visitor, std::shared_ptr<ExecuteFunctionVisitor>> efv(m, "ExecuteFunctionVisitor");
+        efv.def(py::init([](py::args& args){
+            return ExecuteFunctionVisitor(args[0]);
+        }));
+
+        m.def("_test_getCategoryName_test_", [](Visitor& v){ return v.getCategoryName(); });
+    }
+
+}  // namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Visitor.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Visitor.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <sofa/simulation/Visitor.h>
+#include <SofaPython3/config.h>
+
+#include <pybind11/pybind11.h>
+
+template class pybind11::class_<sofa::simulation::Visitor,
+                                std::shared_ptr<sofa::simulation::Visitor>>;
+
+namespace sofapython3
+{
+
+namespace py { using namespace pybind11; }
+
+void moduleAddVisitor(py::module &m);
+
+} /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -12,6 +12,7 @@
 #include "Binding_ForceField.h"
 #include "Binding_Controller.h"
 #include "Binding_DataEngine.h"
+#include "Binding_Visitor.h"
 #include "Binding_Node.h"
 #include "Binding_Simulation.h"
 #include "Binding_BaseLink.h"
@@ -82,6 +83,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddController(core);
     moduleAddDataEngine(core);
     moduleAddForceField(core);
+    moduleAddVisitor(core);
 
     py::class_<sofa::core::objectmodel::BaseNode,
             sofa::core::objectmodel::Base,

--- a/bindings/Sofa/tests/CMakeLists.txt
+++ b/bindings/Sofa/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PYTHON_FILES
     Core/Controller.py
     Core/ForceField.py
     Core/DataEngine.py
+    Core/Visitor.py
     Core/PythonRestShapeForceField.py
     Core/BaseLink.py
     Helper/Message.py

--- a/bindings/Sofa/tests/Core/Visitor.py
+++ b/bindings/Sofa/tests/Core/Visitor.py
@@ -1,0 +1,70 @@
+# This Python file uses the following encoding: utf-8
+
+import Sofa.Core
+import Sofa.Simulation
+import unittest
+
+def DumpNode(node):
+    print("+ " + str(node.name.value))
+    for o in node.objects:
+        print("  - " + str(o.name.value))
+    return True
+
+
+class MyVisitor(Sofa.Core.Visitor):
+    def __init__(self):
+        Sofa.Core.Visitor.__init__(self)
+
+    def processNodeTopDown(self, node):
+        DumpNode(node)
+        return True
+
+    def processNodeBottomUp(self, node):
+        pass
+
+    def getCategoryName(self):
+        return "plop"
+
+class Test(unittest.TestCase):
+    def test_visitor(self):
+        node = Sofa.Core.Node("root")
+        node.addObject("MechanicalObject" , name="AnObject1")
+        node.addObject("MechanicalObject" , name="AnObject2")
+        node.addObject("MechanicalObject" , name="AnObject3")
+        node.addObject("MechanicalObject" , name="AnObject4")
+
+        n = node.addChild('ANode1')
+        n.addObject("MechanicalObject" , name="AnObject1")
+        n.addObject("MechanicalObject" , name="AnObject2")
+        n.addObject("MechanicalObject" , name="AnObject3")
+
+        n = node.addChild('ANode2')
+        n.addObject("MechanicalObject" , name="AnObject1")
+        n.addObject("MechanicalObject" , name="AnObject2")
+        n.addObject("MechanicalObject" , name="AnObject3")
+
+        n = n.addChild('ANode')
+        n.addObject("MechanicalObject" , name="AnObject1")
+        n.addObject("MechanicalObject" , name="AnObject2")
+        n.addObject("MechanicalObject" , name="AnObject3")
+
+        Sofa.Simulation.init(node)
+
+        # A good hack to create visitors without having to
+        # create python classes (only supports processNodeTopDown)
+        v = Sofa.Core.ExecuteFunctionVisitor(DumpNode)
+        node.execute(v)
+
+        # Works
+        v2 = MyVisitor()
+
+        # Works
+        self.assertEqual(v2.getClassName(), "Sofa.Core.Visitor")
+        self.assertEqual(v2.getCategoryName(), "plop")
+
+        # Works from c++ too, trampoline does its job
+        self.assertEqual(Sofa.Core._test_getCategoryName_test_(v2), "plop")
+
+
+        v2.execute(node, False) # Does not work. WHYYYY?
+        node.execute(v2) # Does not work. WHYYYY?

--- a/src/SofaPython3/DataHelper.cpp
+++ b/src/SofaPython3/DataHelper.cpp
@@ -51,6 +51,22 @@ void PythonTrampoline::setInstance(py::object s)
 });
 }
 
+PythonNonIntrusiveTrampoline::~PythonNonIntrusiveTrampoline(){}
+void PythonNonIntrusiveTrampoline::setInstance(py::object s)
+{
+    s.inc_ref();
+
+    // TODO(bruno-marques) ici ça crash dans SOFA.
+    //--ref_counter;
+
+    pyobject = std::shared_ptr<PyObject>( s.ptr(), [](PyObject* ob)
+    {
+            // runSofa Sofa/tests/pyfiles/ScriptController.py => CRASH
+            // Py_DECREF(ob);
+});
+}
+
+
 std::ostream& operator<<(std::ostream& out, const py::buffer_info& p)
 {
     out << "buffer{"<< p.format << ", " << p.ndim << ", " << p.shape[0];

--- a/src/SofaPython3/DataHelper.h
+++ b/src/SofaPython3/DataHelper.h
@@ -46,7 +46,7 @@ public:
     virtual void SOFAPYTHON3_API setInstance(py::object s);
 };
 
-template <typename T> class py_shared_ptr : public sofa::core::sptr<T>
+template <typename T> class SOFAPYTHON3_API py_shared_ptr : public sofa::core::sptr<T>
 {
 public:
     py_shared_ptr(T *ptr) : sofa::core::sptr<T>(ptr)
@@ -56,6 +56,31 @@ public:
             nptr->setInstance( py::cast(ptr) ) ;
     }
 };
+
+
+
+class SOFAPYTHON3_API PythonNonIntrusiveTrampoline
+{
+protected:
+    std::shared_ptr<PyObject> pyobject;
+public:
+    virtual ~PythonNonIntrusiveTrampoline();
+    virtual void SOFAPYTHON3_API setInstance(py::object s);
+};
+
+template <typename T> class SOFAPYTHON3_API py_non_intrusive_ptr : public std::shared_ptr<T>
+{
+public:
+    py_non_intrusive_ptr(T *ptr) : std::shared_ptr<T>(ptr)
+    {
+        auto nptr = dynamic_cast<PythonTrampoline*>(ptr);
+        if(nptr)
+            nptr->setInstance( py::cast(ptr) ) ;
+    }
+};
+
+
+
 
 void SOFAPYTHON3_API setItem2D(py::array a, py::slice slice, py::object o);
 void SOFAPYTHON3_API setItem2D(py::array a, const py::slice& slice,


### PR DESCRIPTION
Ma meilleure implémentation d'un binding pour les Visitors dans SOFA....:

Comme sofa::simulation::Visitor n'hérite pas de Base, je ne peux pas utiliser le PythonTrampoline ni le py_shared_ptr qui partent du principe que le pointeur possède les props des boost::intrusive_ptr.
J'ai donc ajouté une class PythonNonIntrusiveTrampoline et un py_non_intrusive_ptr pour pouvoir stocker le pyobject à la construction. (c.f. py::init() pour Sofa.Core.Visitor)

Le trampoline semble faire son boulot (c.f Visitor.py) et les appels à get{Class,Category}Name marchent depuis python ET depuis le c++.

Pourtant, la fonction execute ne marche pas! Pourquoi, je ne sais pas. une idée @damienmarchal ? 