### PR TITLE
FIX: bounding box inherited methods and properties from BaseData

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.cpp
@@ -35,7 +35,8 @@ namespace sofapython3 {
 
 void moduleAddBoundingBox(py::module& m)
 {
-    py::class_<sofa::Data<BoundingBox>> bbox(m, "BoundingBox");
+    py::class_<BoundingBoxData, BaseData,
+            raw_ptr<BoundingBoxData> > bbox(m, "BoundingBox");
     bbox.def("getMin", [](sofa::Data<BoundingBox>& bbox) {
         py::list list;
         list.append(bbox.getValue().minBBox()[0]);
@@ -76,8 +77,8 @@ void moduleAddBoundingBox(py::module& m)
 
     std::cout << "Lets register BoundingBox" << std::endl;
 
-    PythonFactory::registerType<sofa::Data<BoundingBox>>("BoundingBox", [](BaseData* data) -> py::object {
-        return py::cast(reinterpret_cast<sofa::Data<BoundingBox>*>(data));
+    PythonFactory::registerType<BoundingBoxData>("BoundingBox", [](BaseData* data) -> py::object {
+        return py::cast(reinterpret_cast<BoundingBoxData*>(data));
     });
 
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.h
@@ -29,12 +29,21 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 
 #include <pybind11/pybind11.h>
 
+#include <SofaPython3/DataHelper.h>
 #include <sofa/defaulttype/BoundingBox.h>
+#include <sofa/core/objectmodel/Data.h>
 using sofa::defaulttype::BoundingBox;
+
+
+class BoundingBoxData : public sofa::Data<BoundingBox> {};
+PYBIND11_DECLARE_HOLDER_TYPE(BoundingBoxData, sofapython3::raw_ptr<BoundingBoxData>)
+
+template class pybind11::class_<BoundingBoxData, sofapython3::raw_ptr<BoundingBoxData>>;
 
 namespace sofapython3 {
 
 namespace py { using namespace pybind11; }
+
 
 void moduleAddBoundingBox(py::module& m);
 


### PR DESCRIPTION
@p-shg this fix should solve #98 

The BoundingBox type holder was missing in the pybind11 type declaration

Tell me if it's working out for you