### PR TITLE
FIX: exception thrown when forgetting to call super in initializer

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
@@ -56,24 +56,23 @@ using sofa::core::sptr;
 class BindingBase
 {
 public:
-    static void SetAttr(Base& self, const std::string& s, py::object value);
-
-    static void SetAttr(py::object self, const std::string& s, pybind11::object value);
-    static py::object GetAttr(Base* self, const std::string& s, bool doThrowException=true);
+    static void SetAttr(py::object self, const std::string& s, py::object value);
+    static bool SetAttr(Base* self, const std::string& s, py::object value);
+    static py::object GetAttr(py::object self, const std::string& s, bool doThrowException=true);
     static void SetAttrFromArray(py::object self, const std::string& s, const pybind11::array &value);
 
     /// Set the data field value from the array.
     static void SetDataFromArray(BaseData* data, const py::array& value);
     static bool SetData(BaseData* data, pybind11::object value);
 
-    static py::list getDataFields(Base& self);
-    static py::list getLinks(Base& self);
+    static py::list getDataFields(py::object self);
+    static py::list getLinks(py::object self);
     static void addData(py::object py_self, const std::string& name, py::object value = py::object(), py::object defaultValue = py::object(), const std::string& help = "", const std::string& group = "Property", std::string type = "");
-    static void addDataFromData(Base* self, py::object d);
-    static py::list __dir__(Base* self);
+    static void addDataFromData(py::object self, py::object d);
+    static py::list __dir__(py::object self);
     static py::object __getattr__(py::object self, const std::string& s);
     static void __setattr__(py::object self, const std::string& s, py::object value);
-    static py::object getData(Base& self, const std::string&);
+    static py::object getData(py::object self, const std::string&);
 };
 
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Controller.cpp
@@ -146,7 +146,7 @@ namespace sofapython3
                       if( key == "name")
                           c->setName(py::cast<std::string>(kv.second));
                       try {
-                          BindingBase::SetAttr(*c, key, value);
+                          BindingBase::SetAttr(c, key, value);
                       } catch (py::attribute_error& /*e*/) {
                           /// kwargs are used to set datafields to their initial values,
                           /// but they can also be used as simple python attributes, unrelated to SOFA.

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -117,7 +117,7 @@ namespace sofapython3
                       if( key == "name")
                       c->setName(py::cast<std::string>(kv.second));
                       try {
-                          BindingBase::SetAttr(*c, key, value);
+                          BindingBase::SetAttr(c, key, value);
                       } catch (py::attribute_error& /*e*/) {
                           /// kwargs are used to set datafields to their initial values,
                           /// but they can also be used as simple python attributes, unrelated to SOFA.

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -66,6 +66,7 @@ using sofa::core::objectmodel::BaseObjectDescription;
 namespace sofapython3
 {
 
+namespace bindingnode {
 
 bool checkParamUsage(BaseObjectDescription& desc)
 {
@@ -274,20 +275,21 @@ NodeIterator* property_objects(Node* node)
 });
 }
 
-py::object __getattr__(Node& self, const std::string& name)
+py::object __getattr__(py::object self, const std::string& name)
 {
+    Node* node = PythonFactory::cast<Node*>(self);
     /// Search in the object lists
-    BaseObject *object = self.getObject(name);
+    BaseObject *object = node->getObject(name);
     if (object)
         return PythonFactory::toPython(object);
 
     /// Search in the child lists
-    Node *child = self.getChild(name);
+    Node *child = node->getChild(name);
     if (child)
         return PythonFactory::toPython(child);
 
     /// Search in the data & link lists
-    return BindingBase::GetAttr(&self, name, true);
+    return BindingBase::GetAttr(self, name, true);
 }
 
 /// gets an item using its path (path is dot-separated, relative to the object
@@ -378,6 +380,8 @@ void sendEvent(Node* self, py::object pyUserData, char* eventName)
     self->propagateEvent(sofa::core::ExecParams::defaultInstance(), &event);
 }
 
+}
+
 void moduleAddNode(py::module &m) {
     /// Register the complete parent-child relationship between Base and Node to the pybind11
     /// typing system.
@@ -403,37 +407,37 @@ void moduleAddNode(py::module &m) {
         return py::cast(static_cast<Node*>(object->toBaseNode()));
     });
 
-    p.def(py::init(&__init__noname), sofapython3::doc::sofa::core::Node::init);
-    p.def(py::init(&__init__), sofapython3::doc::sofa::core::Node::init1Arg, py::arg("name"));
-    p.def("init", &init, sofapython3::doc::sofa::core::Node::initSofa );
-    p.def("addObject", &addObjectKwargs, sofapython3::doc::sofa::core::Node::addObjectKwargs);
-    p.def("addObject", &addObject, sofapython3::doc::sofa::core::Node::addObject);
-    p.def("createObject", &createObject, sofapython3::doc::sofa::core::Node::createObject);
-    p.def("addChild", &addChildKwargs, sofapython3::doc::sofa::core::Node::addChildKwargs);
-    p.def("addChild", &addChild, sofapython3::doc::sofa::core::Node::addChild);
-    p.def("createChild", &createChild, sofapython3::doc::sofa::core::Node::createChild);
-    p.def("getChild", &getChild, sofapython3::doc::sofa::core::Node::getChild);
-    p.def("removeChild", &removeChild, sofapython3::doc::sofa::core::Node::removeChild);
-    p.def("removeChild", &removeChildByName, sofapython3::doc::sofa::core::Node::removeChildWithName);
+    p.def(py::init(&bindingnode::__init__noname), sofapython3::doc::sofa::core::Node::init);
+    p.def(py::init(&bindingnode::__init__), sofapython3::doc::sofa::core::Node::init1Arg, py::arg("name"));
+    p.def("init", &bindingnode::init, sofapython3::doc::sofa::core::Node::initSofa );
+    p.def("addObject", &bindingnode::addObjectKwargs, sofapython3::doc::sofa::core::Node::addObjectKwargs);
+    p.def("addObject", &bindingnode::addObject, sofapython3::doc::sofa::core::Node::addObject);
+    p.def("createObject", &bindingnode::createObject, sofapython3::doc::sofa::core::Node::createObject);
+    p.def("addChild", &bindingnode::addChildKwargs, sofapython3::doc::sofa::core::Node::addChildKwargs);
+    p.def("addChild", &bindingnode::addChild, sofapython3::doc::sofa::core::Node::addChild);
+    p.def("createChild", &bindingnode::createChild, sofapython3::doc::sofa::core::Node::createChild);
+    p.def("getChild", &bindingnode::getChild, sofapython3::doc::sofa::core::Node::getChild);
+    p.def("removeChild", &bindingnode::removeChild, sofapython3::doc::sofa::core::Node::removeChild);
+    p.def("removeChild", &bindingnode::removeChildByName, sofapython3::doc::sofa::core::Node::removeChildWithName);
     p.def("getRoot", &Node::getRoot, sofapython3::doc::sofa::core::Node::getRoot);
     p.def("getPathName", &Node::getPathName, sofapython3::doc::sofa::core::Node::getPathName);
-    p.def("getLinkPath", &getLinkPath, sofapython3::doc::sofa::core::Node::getLinkPath);
-    p.def_property_readonly("children", &property_children, sofapython3::doc::sofa::core::Node::children);
-    p.def_property_readonly("parents", &property_parents, sofapython3::doc::sofa::core::Node::parents);
-    p.def_property_readonly("objects", &property_objects, sofapython3::doc::sofa::core::Node::objects);
-    p.def("__getattr__", &__getattr__);
-    p.def("__getitem__", &__getitem__);
+    p.def("getLinkPath", &bindingnode::getLinkPath, sofapython3::doc::sofa::core::Node::getLinkPath);
+    p.def_property_readonly("children", &bindingnode::property_children, sofapython3::doc::sofa::core::Node::children);
+    p.def_property_readonly("parents", &bindingnode::property_parents, sofapython3::doc::sofa::core::Node::parents);
+    p.def_property_readonly("objects", &bindingnode::property_objects, sofapython3::doc::sofa::core::Node::objects);
+    p.def("__getattr__", &bindingnode::__getattr__);
+    p.def("__getitem__", &bindingnode::__getitem__);
     p.def("removeObject", &Node::removeObject, sofapython3::doc::sofa::core::Node::removeObject);
     p.def("getRootPath", &Node::getRootPath, sofapython3::doc::sofa::core::Node::getRootPath);
-    p.def("moveChild", &moveChild, sofapython3::doc::sofa::core::Node::moveChild);
+    p.def("moveChild", &bindingnode::moveChild, sofapython3::doc::sofa::core::Node::moveChild);
     p.def("isInitialized", &Node::isInitialized, sofapython3::doc::sofa::core::Node::isInitialized);
-    p.def("getAsACreateObjectParameter", &getLinkPath, sofapython3::doc::sofa::core::Node::getAsACreateObjectParameter);
+    p.def("getAsACreateObjectParameter", &bindingnode::getLinkPath, sofapython3::doc::sofa::core::Node::getAsACreateObjectParameter);
     p.def("detachFromGraph", &Node::detachFromGraph, sofapython3::doc::sofa::core::Node::detachFromGraph);
-    p.def("getMass", &getMass, sofapython3::doc::sofa::core::Node::getMass);
-    p.def("getForceField", &getForceField, sofapython3::doc::sofa::core::Node::getForceField);
-    p.def("getMechanicalState", &getMechanicalState, sofapython3::doc::sofa::core::Node::getMechanicalState);
-    p.def("getMechanicalMapping", &getMechanicalMapping, sofapython3::doc::sofa::core::Node::getMechanicalMapping);
-    p.def("sendEvent", &sendEvent, sofapython3::doc::sofa::core::Node::sendEvent);
+    p.def("getMass", &bindingnode::getMass, sofapython3::doc::sofa::core::Node::getMass);
+    p.def("getForceField", &bindingnode::getForceField, sofapython3::doc::sofa::core::Node::getForceField);
+    p.def("getMechanicalState", &bindingnode::getMechanicalState, sofapython3::doc::sofa::core::Node::getMechanicalState);
+    p.def("getMechanicalMapping", &bindingnode::getMechanicalMapping, sofapython3::doc::sofa::core::Node::getMechanicalMapping);
+    p.def("sendEvent", &bindingnode::sendEvent, sofapython3::doc::sofa::core::Node::sendEvent);
 
 }
 } /// namespace sofapython3

--- a/src/SofaPython3/PythonFactory.h
+++ b/src/SofaPython3/PythonFactory.h
@@ -83,6 +83,14 @@ namespace sofapython3
             s_dataCreationFct[s] = [](){ return new sofa::core::objectmodel::Data<T>(); };
         }
 
+        template <class T>
+        static T SOFAPYTHON3_API cast(py::object& o) {
+            if (!py::isinstance<T>(o))
+                // @bmarques TODO: better error message, of course...
+                throw py::value_error("self does not inherit c++ Base instance. make sure you've called super in the initializer");
+            return py::cast<T>(o);
+        }
+
         static std::map<std::string, componentDowncastingFunction>::iterator SOFAPYTHON3_API searchLowestCastAvailable(const sofa::core::objectmodel::BaseClass* metaclass);
 
         static void SOFAPYTHON3_API uniqueKeys(std::back_insert_iterator<sofa::helper::vector<std::string> > it);


### PR DESCRIPTION
@damienmarchal  Here's a proposition to try to tackle the issue of users forgetting to call super in the initializer method of SOFA Python classes (Controllers, DataEngines, Forcefields etc.) (#96)

Basically the crash happens when the binding function tries to py::cast the py::object (self) into a C++ SOFA type such as Node, Base, etc, while the trampoline instance was not created.

The only moment we can detect that a class tries to access data that are held by a missing trampoline, is inside the binding itself, before the cast.

This PR does 2 things:
- It wraps py::cast into a method called PythonFactory::cast() that checks if the cast can succeed (if the trampoline exists) and throws a value_error if it can't.
- It replaces all calls to py::cast with the new function in the bindings of Base, and replaces all bindings assuming a Base* or Base& as self, with an equivalent using  a py::object so that we can introspect first (the same has to be done for all other bindings) so that no implicit cast is performed.
`base.def("getName", [](Base& b){ return b.getName(); }, sofapython3::doc::base::getName);` becomes `base.def("getName", [](py::object self){ return PythonFactory::cast<Base*>(self)->getName(); }, sofapython3::doc::base::getName);`
This: `base.def("getClassName",&Base::getClassName, sofapython3::doc::base::getClassName);` Will have to be forbidden (as it performs an implicit cast to Base*)

This is more of a POC that an actual solution because:
- I don't believe that we can guarantee on the long run that no-one will ever implement a shortcut version without using our PythonFactory::cast method
- The error message is shitty, and the exception can be thrown for other reasons than a missing trampoline, which makes it hard to provide an appropriate error message for all situations

Let me know what you think!