### PR TITLE
FIX: Removing the callstack that crashes the interpreter in SofaRuntime

### DIFF
--- a/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
+++ b/bindings/SofaRuntime/src/SofaPython3/SofaRuntime/Module_SofaRuntime.cpp
@@ -124,7 +124,7 @@ PYBIND11_MODULE(SofaRuntime, m) {
     if( !SceneLoaderFactory::getInstance()->getEntryFileExtension("py3") )
     {
         SceneLoaderFactory::getInstance()->addEntry(new SceneLoaderPY3());
-        sofa::helper::BackTrace::autodump();
+//        sofa::helper::BackTrace::autodump();  // We don't want to catch SIGINT in the python interpreter
     }
 
     m.def("importPlugin", [](const std::string& name)


### PR DESCRIPTION
Fixes #100, although probably removes an interesting feature (that I don't get...)