### PR TITLE
Fixe & Feature in BaseData &ForceField

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseData.cpp
@@ -131,7 +131,7 @@ void __setattr__(py::object self, const std::string& s, py::object value)
         BindingBase::SetDataFromArray(selfdata, py::cast<py::array>(value));
         return;
     }
-    BindingBase::SetAttr(py::cast(selfdata->getOwner()),s,value);
+    BindingBase::SetAttr(py::cast(selfdata->getOwner()),selfdata->getName(),value);
 }
 
 py::object __getattr__(py::object self, const std::string& s)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ForceField.h
@@ -37,16 +37,25 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 
 namespace sofapython3
 {
-class SOFAPYTHON3_API ForceField_Trampoline  : public sofa::core::behavior::ForceField<sofa::defaulttype::Vec3dTypes>, public PythonTrampoline
+
+template<class TDOFType>
+class SOFAPYTHON3_API ForceField_Trampoline  : public sofa::core::behavior::ForceField<TDOFType>, public PythonTrampoline
 {
+
 public:
+    using sofa::core::behavior::ForceField<TDOFType>::mstate;
+    using sofa::core::behavior::ForceField<TDOFType>::getContext;
+    using typename sofa::core::behavior::ForceField<TDOFType>::DataTypes;
+    using typename sofa::core::behavior::ForceField<TDOFType>::Coord;
+    using typename sofa::core::behavior::ForceField<TDOFType>::DataVecDeriv;
+    using typename sofa::core::behavior::ForceField<TDOFType>::DataVecCoord;
+
     ForceField_Trampoline();
     ~ForceField_Trampoline() override;
 
     void init() override;
 
-    void addForce(const sofa::core::MechanicalParams* mparams,  DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
-
+    void addForce(const sofa::core::MechanicalParams* mparams, DataVecDeriv& f, const DataVecCoord& x, const DataVecDeriv& v) override;
     void addDForce(const sofa::core::MechanicalParams* mparams, DataVecDeriv& df, const DataVecDeriv& dx ) override;
 
     py::object _addKToMatrix(const sofa::core::MechanicalParams* mparams, int nNodes, int nDofs);


### PR DESCRIPTION
In this PR there is two things.

A Fix, for setting a data field value  in BaseData. The current implementation is not working as it was searching for the "value" string instead of the actual data name. 

A new feature, the force field binding are only implement Vec3. So I change that so we could create Rigid3. I'm not very happy with the implementation but was in a urge.


