### PR TITLE
Adds a first sofa module SofaBaseTopology with regular dense and sparse grid components

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(Sofa)
 add_subdirectory(SofaRuntime)
 add_subdirectory(SofaGui)
 add_subdirectory(SofaTypes)
+add_subdirectory(Modules)
 
 find_package(SofaExporter QUIET)
 if (SofaExporter_FOUND)

--- a/bindings/Modules/CMakeLists.txt
+++ b/bindings/Modules/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.1)
+
+add_subdirectory(src/SofaPython3/SofaBaseTopology)

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_RegularGridTopology.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_RegularGridTopology.cpp
@@ -1,0 +1,47 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#include <pybind11/pybind11.h>
+#include "Binding_RegularGridTopology.h"
+#include "Binding_RegularGridTopology_doc.h"
+
+#include <SofaBaseTopology/RegularGridTopology.h>
+
+using sofa::component::topology::RegularGridTopology;
+using sofa::core::objectmodel::BaseObject;
+
+namespace sofapython3 {
+
+namespace py { using namespace pybind11; }
+
+void moduleAddRegularGridTopology(pybind11::module& m) {
+    py::class_<RegularGridTopology> c(m, "RegularGridTopology", doc::SofaBaseTopology::regularGridTopologyClass);
+
+    c.def("getPoint", &RegularGridTopology::getPoint, doc::SofaBaseTopology::getPoint);
+}
+
+} // namespace sofapython3

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_RegularGridTopology.h
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_RegularGridTopology.h
@@ -1,0 +1,36 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddRegularGridTopology(pybind11::module& m);
+
+} // namespace sofapython3

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_RegularGridTopology_doc.h
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_RegularGridTopology_doc.h
@@ -1,0 +1,47 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::SofaBaseTopology {
+
+static auto regularGridTopologyClass =
+R"(
+Regular grid of hexahedral cells in space.
+)";
+
+static auto getPoint =
+R"(
+Get the position of node of the grid from its index.
+
+:param index: The index of the node.
+:type index: int
+
+:return: A vector3 containing the position of the given node index.
+:rtype: Vector3
+)";
+} // sofapython3::doc::SofaBaseTopology

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_SparseGridTopology.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_SparseGridTopology.cpp
@@ -1,0 +1,156 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "Binding_SparseGridTopology.h"
+#include "Binding_SparseGridTopology_doc.h"
+
+#include <SofaBaseTopology/SparseGridTopology.h>
+
+using sofa::component::topology::SparseGridTopology;
+using sofa::core::objectmodel::BaseObject;
+
+
+namespace sofapython3 {
+
+namespace py { using namespace pybind11; }
+
+void moduleAddSparseGridTopology(pybind11::module& m) {
+    py::class_<SparseGridTopology> c(m, "SparseGridTopology", doc::SofaBaseTopology::sparseGridTopologyClass);
+
+    // getRegularGrid ()
+    c.def("getRegularGrid", [](SparseGridTopology & self){
+        return self._regularGrid.get();
+    }, doc::SofaBaseTopology::getRegularGrid);
+
+    // findCube (pos)
+    c.def("findCube", [](SparseGridTopology & self, const py::list & l) {
+        sofa::defaulttype::Vector3 pos;
+        pos[0] = l[0].cast<double>();
+        pos[1] = l[1].cast<double>();
+        pos[2] = l[2].cast<double>();
+
+        SReal fx=0., fy=0., fz=0.;
+        SReal dx=self._regularGrid->getDx()[0];
+        SReal dy=self._regularGrid->getDy()[1];
+        SReal dz=self._regularGrid->getDz()[2];
+
+        int cube_id = self.findCube(pos, fx, fy, fz);
+
+        if (cube_id < 0) {
+            // It may be a node
+            const int node_id = self._regularGrid->findPoint(pos);
+            if (node_id > -1) {
+                // It is a node, find the first hexa connected to this node that is either inside or on the boundary
+                const auto&  hexas = self._regularGrid->getHexahedraAroundVertex(node_id);
+                for (const auto & hexa_id : hexas) {
+                    if (self._indicesOfRegularCubeInSparseGrid[hexa_id] > -1) {
+                        auto p = pos-self._regularGrid->d_p0.getValue();
+
+                        SReal x = p[0]/dx;
+                        SReal y = p[1]/dy;
+                        SReal z = p[2]/dz;
+
+                        int ix = int(x+1000000)-1000000; // Do not round toward 0...
+                        int iy = int(y+1000000)-1000000;
+                        int iz = int(z+1000000)-1000000;
+
+                        fx = x-ix;
+                        fy = y-iy;
+                        fz = z-iz;
+                        cube_id = self._indicesOfRegularCubeInSparseGrid[hexa_id];
+                        break;
+                    }
+                }
+            }
+        }
+
+        return py::make_tuple(cube_id, fx, fy, fz);
+    }, doc::SofaBaseTopology::findCube);
+
+    // getRegularGridNodeIndex (sparse_grid_node_index)
+    c.def("getRegularGridNodeIndex", [](SparseGridTopology & self, size_t sparse_grid_node_index) {
+        if (sparse_grid_node_index >= self.getNbPoints()) {
+            throw py::index_error(
+                "Node index " + std::to_string(sparse_grid_node_index) + " is greater then the number of nodes contained by "
+                "the sparse grid (" + std::to_string(self.getNbPoints()) + " nodes).");
+        }
+
+        const auto pos = self.getPointPos(sparse_grid_node_index);
+        return self._regularGrid->findPoint(pos);
+    }, doc::SofaBaseTopology::getRegularGridNodeIndex);
+
+    // getRegularGridCubeIndex (sparse_grid_cube_index)
+    c.def("getRegularGridCubeIndex", [](SparseGridTopology & self, size_t sparse_grid_cube_index) {
+        if (sparse_grid_cube_index >= self.getNbHexahedra()) {
+            throw py::index_error(
+                    "Cube index " + std::to_string(sparse_grid_cube_index) + " is greater then the number of cubes contained by "
+                         "the sparse grid (" + std::to_string(self.getNbHexahedra()) + " cubes).");
+        }
+
+        return self._indicesOfCubeinRegularGrid[sparse_grid_cube_index];
+    }, doc::SofaBaseTopology::getRegularGridCubeIndex);
+
+    // getBoundaryCells ()
+    c.def("getBoundaryCells", [] (SparseGridTopology & self) {
+        std::list<unsigned int> indices;
+        for (std::size_t hexa_id = 0; hexa_id < self.getNbHexahedra(); ++hexa_id) {
+            if (self.getType((int)hexa_id) == SparseGridTopology::BOUNDARY)
+                indices.push_back(hexa_id);
+        }
+        return indices;
+    }, doc::SofaBaseTopology::getBoundaryCells);
+
+    // getBoundaryNodes ()
+    c.def("getBoundaryNodes", [] (SparseGridTopology & self) {
+        std::list<unsigned int> indices;
+        for (std::size_t node_id = 0; node_id < self.getNbPoints(); ++node_id) {
+            auto nb_of_connected_hexa = self.getHexahedraAroundVertex(node_id).size();
+            if (nb_of_connected_hexa < 7)
+                indices.push_back(node_id);
+        }
+        return indices;
+    }, doc::SofaBaseTopology::getBoundaryNodes);
+
+    // getNodeIndicesOfCube (cube_index)
+    c.def("getNodeIndicesOfCube", [](SparseGridTopology & self, size_t cube_index) {
+        if (cube_index >= self.getNbHexahedra()) {
+            throw py::index_error(
+                    "Cube index " + std::to_string(cube_index) + " is greater then the number of cubes contained by "
+                         "the sparse grid (" + std::to_string(self.getNbHexahedra()) + " cubes).");
+        }
+        const auto hexa = self.getHexahedron(cube_index);
+        std::array<sofa::core::topology::Topology::PointID, 8> indices = {};
+        for (std::size_t i = 0; i < 8; ++i) {
+            indices[i] = hexa[i];
+        }
+        return indices;
+    }, doc::SofaBaseTopology::getRegularGridCubeIndex);
+}
+
+} // namespace sofapython3

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_SparseGridTopology.h
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_SparseGridTopology.h
@@ -1,0 +1,36 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddSparseGridTopology(pybind11::module& m);
+
+} // namespace sofapython3

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_SparseGridTopology_doc.h
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Binding_SparseGridTopology_doc.h
@@ -1,0 +1,100 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::SofaBaseTopology {
+
+static auto sparseGridTopologyClass =
+R"(
+A sparse grid topology. Like a sparse FFD building from the bounding box of the object. Starting from a RegularGrid,
+only valid cells containing matter (ie intersecting the original surface mesh or totally inside the object) are
+considered. Valid cells are tagged by a Type BOUNDARY or INSIDE.
+
+WARNING: the corresponding node in the XML file has to be placed BEFORE the MechanicalObject node, in order to excute
+its init() before the MechanicalObject one in order to be able to give dofs
+)";
+
+static auto getRegularGrid =
+R"(
+Get the underneath regular grid object of this sparse grid.
+
+:rtype: RegularGridTopology
+)";
+
+static auto findCube =
+R"(
+Returns the cube containing the given point (or -1 if not found), as well as deplacements from its first corner in terms
+of dx, dy, dz (i.e. barycentric coordinates).
+
+:return: (cube_id, u, v, w)
+:rtype: tuple
+)";
+
+static auto getRegularGridNodeIndex =
+R"(
+Get the index of a given node in the underneath regular grid.
+
+:param index: The index of the node in the sparse grid.
+
+:return: The index of the node in the regular grid.
+:rtype: int
+)";
+
+static auto getRegularGridCubeIndex =
+R"(
+Get the index of a given cube in the underneath regular grid.
+
+:param index: The index of the cube in the sparse grid.
+
+:return: The index of the cube in the regular grid.
+:rtype: int
+)";
+
+static auto getBoundaryCells =
+R"(
+Get the indices of the cells in this grid that lie on the boundary (i.e. intersect the surface mesh).
+:rtype: list
+)";
+
+static auto getBoundaryNodes =
+R"(
+Get the indices of the nodes that forms the boundary of the grid (i.e. have less than 7 connected cells).
+:rtype: list
+)";
+
+static auto getNodeIndicesOfCube =
+R"(
+Get the indices of the nodes of a given cube (grid cell).
+
+:param index: The index of the cube.
+
+:return: A list containing the indices of the cube nodes
+:rtype: list
+)";
+
+} // sofapython3::doc::SofaBaseTopology

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.1)
+project(PythonModule_SofaBaseTopology)
+
+set(SOURCE_FILES
+    Binding_RegularGridTopology.cpp
+    Binding_SparseGridTopology.cpp
+    Module_SofaBaseTopology.cpp
+)
+
+set(HEADER_FILES
+    Binding_RegularGridTopology.h
+    Binding_RegularGridTopology_doc.h
+    Binding_SparseGridTopology.h
+    Binding_SparseGridTopology_doc.h
+)
+
+SP3_add_python_module(
+    TARGET
+        ${PROJECT_NAME}
+    MODULE_NAME
+        SofaBaseTopology
+    SOURCES
+        ${SOURCE_FILES}
+        ${HEADER_FILES}
+    DEPENDS
+        SofaBaseTopology SofaPython3
+    DESTINATION
+        ${SP3_PYTHON_PACKAGES_DIRECTORY}
+)

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
@@ -1,0 +1,44 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#include <pybind11/pybind11.h>
+
+#include "Binding_RegularGridTopology.h"
+#include "Binding_SparseGridTopology.h"
+
+namespace py { using namespace pybind11; }
+
+namespace sofapython3
+{
+
+PYBIND11_MODULE(SofaBaseTopology, m)
+{
+    moduleAddRegularGridTopology(m);
+    moduleAddSparseGridTopology(m);
+}
+
+} // namespace sofapython3


### PR DESCRIPTION
Following [our discussion](https://gitter.im/plugin-SofaPython3/community?at=5d321469985141668731b3a2) on gitter, I've add the bindings for a first Sofa "module" : SofaBaseTopology, as I needed some methods from dense and sparse regular grid components.

You need to import the module **SofaBaseTopology** in Python in order for the addObject function to return the good bindings of the component.

Example:
**Without SofaBaseTopology**
```
>>> n.addObject('SparseGridTopology')
<Sofa.Core.Object object at 0x7f7607567ef0>
``` 
**With SofaBaseTopology**
```
>>> import SofaBaseTopology
>>> n.addObject('SparseGridTopology')
<SofaBaseTopology.SparseGridTopology object at 0x7f760756edf0>
```