### PR TITLE
Use the factory downcast method for node addObject with kwargs binding.

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -190,7 +190,7 @@ py::object addObjectKwargs(Node* self, const std::string& type, const py::kwargs
         throw py::value_error(object->getLoggedMessagesAsString({Message::Error}));
     }
 
-    return py::cast(object);
+    return PythonFactory::toPython(object.get());
 }
 
 /// Only addObject is needed now, the createObject is deprecated and will prints


### PR DESCRIPTION
@damienmarchal if you could confirm this: the `node::addObject(object)` is using the factory downcast method (`PythonFactory::toPython`), while the `node::addObject(kwargs)` was not. I think this is a small mistake, whereas the later should also use the factory to get the good python component for the object.

If we don't do this, then adding a component that has not been bound, but have a parent class that was, the py::cast won't use its parent python component. 

This PR fixes this.