### PR TITLE
Add a new custom target that will trigger the build of every python modules

### DIFF
--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -124,6 +124,10 @@ function(SP3_add_python_module)
 
         install(TARGETS ${A_TARGET} LIBRARY DESTINATION ${DESTINATION})
 
+        if (TARGET ALL_BINDINGS)
+            add_dependencies(ALL_BINDINGS ${A_TARGET})
+        endif()
+
         if (NOT A_QUIET)
             message(STATUS "Python module '${MODULE_NAME}' added to ${DESTINATION} (python version ${PYTHON_VERSION_STRING}, pybind11 version ${pybind11_VERSION})")
         endif ()

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -16,6 +16,9 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/installed-bindings-config"
     DESTINATION "etc/sofa/python.d"
     RENAME "plugin.SofaPython3.bindings")
 
+# Add a new custom target that will trigger the build of every python modules
+add_custom_target(ALL_BINDINGS)
+
 add_subdirectory(Sofa)
 add_subdirectory(SofaRuntime)
 add_subdirectory(SofaGui)


### PR DESCRIPTION
Very simple custom target that will make available the build of all python modules in most IDE with one click.