### PR TITLE
Force static variables from the python factory to be in a single compilation unit.

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.cpp
@@ -55,7 +55,7 @@ void moduleAddDataContainer(py::module& m)
     py::class_<DataContainer, BaseData, raw_ptr<DataContainer>> p(m, "DataContainer",
                                                                   py::buffer_protocol(), sofapython3::doc::datacontainer::Class);
 
-    PythonFactory::registerType<DataContainer>("DataContainer", [](BaseData* data) -> py::object {
+    PythonFactory::registerType("DataContainer", [](BaseData* data) -> py::object {
         return py::cast(reinterpret_cast<DataContainer*>(data));
     });
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataString.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataString.cpp
@@ -83,7 +83,7 @@ void moduleAddDataString(py::module& m)
 {
     py::class_<DataString, BaseData, raw_ptr<DataString>> s(m, "DataString");
 
-    PythonFactory::registerType<DataString>("DataString", [](BaseData* data) -> py::object {
+    PythonFactory::registerType("DataString", [](BaseData* data) -> py::object {
         return py::cast(reinterpret_cast<DataString*>(data));
     });
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.cpp
@@ -76,7 +76,7 @@ void moduleAddDataVectorString(py::module& m)
 {
     py::class_<DataVectorString, BaseData, raw_ptr<DataVectorString>> s(m, "DataVectorString");
 
-    PythonFactory::registerType<DataVectorString>("DataVectorString", [](BaseData* data) -> py::object {
+    PythonFactory::registerType("DataVectorString", [](BaseData* data) -> py::object {
         return py::cast(reinterpret_cast<DataVectorString*>(data));
     });
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Types/Binding_BoundingBox.cpp
@@ -77,7 +77,7 @@ void moduleAddBoundingBox(py::module& m)
 
     std::cout << "Lets register BoundingBox" << std::endl;
 
-    PythonFactory::registerType<BoundingBoxData>("BoundingBox", [](BaseData* data) -> py::object {
+    PythonFactory::registerType("BoundingBox", [](BaseData* data) -> py::object {
         return py::cast(reinterpret_cast<BoundingBoxData*>(data));
     });
 

--- a/bindings/SofaGui/src/SofaPython3/SofaGui/Binding_GUIManager.cpp
+++ b/bindings/SofaGui/src/SofaPython3/SofaGui/Binding_GUIManager.cpp
@@ -113,7 +113,7 @@ void moduleAddGuiManager(py::module& m)
     )doc";
     guiManager.def_static("SetScene", [](sofa::simulation::Node & node, const char * filename = nullptr, bool temporaryFile = false) {
         sofa::gui::GUIManager::SetScene(&node, filename, temporaryFile);
-    }, setSceneDoc);
+    }, py::arg("root"), py::arg("filename") = nullptr, py::arg("temporaryFile") = false, setSceneDoc);
 
 
     /*

--- a/bindings/SofaTypes/CMakeLists.txt
+++ b/bindings/SofaTypes/CMakeLists.txt
@@ -42,7 +42,7 @@ SP3_add_python_module(
         ${SOURCE_FILES}
         ${HEADER_FILES}
     DEPENDS
-        SofaPython3 SofaDefaultType
+        SofaDefaultType
     DESTINATION
         ${PACKAGE_DIRECTORY}
 )

--- a/src/SofaPython3/PythonFactory.cpp
+++ b/src/SofaPython3/PythonFactory.cpp
@@ -64,13 +64,33 @@ namespace sofapython3
 {
 using namespace pybind11::literals;
 
-std::map<std::string, componentDowncastingFunction> PythonFactory::s_componentDowncastingFct;
-std::map<std::string, dataDowncastingFunction> PythonFactory::s_dataDowncastingFct;
-std::map<std::string, eventDowncastingFunction> PythonFactory::s_eventDowncastingFct;
-std::map<std::string, dataCreatorFunction> PythonFactory::s_dataCreationFct;
+static std::map<std::string, componentDowncastingFunction> s_componentDowncastingFct;
+static std::map<std::string, dataDowncastingFunction> s_dataDowncastingFct;
+static std::map<std::string, eventDowncastingFunction> s_eventDowncastingFct;
+static std::map<std::string, dataCreatorFunction> s_dataCreationFct;
 
 bool PythonFactory::defaultTypesRegistered = registerDefaultTypes();
 bool PythonFactory::defaultEventsRegistered = registerDefaultEvents();
+
+void PythonFactory::registerType(const std::string& typeName, componentDowncastingFunction fct)
+{
+    s_componentDowncastingFct[typeName] = fct;
+}
+
+void PythonFactory::registerType(const std::string& typeName, dataDowncastingFunction fct)
+{
+    s_dataDowncastingFct[typeName] = fct;
+}
+
+void PythonFactory::registerType(const std::string& typeName, eventDowncastingFunction fct)
+{
+    s_eventDowncastingFct[typeName] = fct;
+}
+
+void PythonFactory::registerType(const std::string& typeName, dataCreatorFunction fct)
+{
+    s_dataCreationFct[typeName] = fct;
+}
 
 std::map<std::string, componentDowncastingFunction>::iterator PythonFactory::searchLowestCastAvailable(const sofa::core::objectmodel::BaseClass* metaclass)
 {

--- a/src/SofaPython3/PythonFactory.h
+++ b/src/SofaPython3/PythonFactory.h
@@ -49,10 +49,6 @@ namespace sofapython3
 
     class SOFAPYTHON3_API PythonFactory
     {
-        static std::map<std::string, componentDowncastingFunction> s_componentDowncastingFct;
-        static std::map<std::string, dataDowncastingFunction> s_dataDowncastingFct;
-        static std::map<std::string, eventDowncastingFunction> s_eventDowncastingFct;
-        static std::map<std::string, dataCreatorFunction> s_dataCreationFct;
     public:
         static py::object toPython(sofa::core::objectmodel::Base* object);
         static py::object toPython(const sofa::core::objectmodel::BaseData* data);
@@ -62,26 +58,27 @@ namespace sofapython3
         static py::object toPython(sofa::core::objectmodel::Event* event);
         static sofa::core::objectmodel::BaseData* createInstance(const std::string& typeName);
 
+        static void registerType(const std::string& typeName, componentDowncastingFunction fct);
+        static void registerType(const std::string& typeName, dataDowncastingFunction fct);
+        static void registerType(const std::string& typeName, eventDowncastingFunction fct);
+        static void registerType(const std::string& typeName, dataCreatorFunction fct);
+
         template<class T>
         static void registerType(componentDowncastingFunction fct)
         {
-            PythonFactory::s_componentDowncastingFct[T::GetClass()->className] = fct;
+            registerType(T::GetClass()->className, fct);
         }
-        template<class T>
-        static void registerType(const std::string& typeName, dataDowncastingFunction fct)
-        {
-            PythonFactory::s_dataDowncastingFct[typeName] = fct;
-        }
+
         template<class T>
         static void registerType(eventDowncastingFunction fct)
         {
-            PythonFactory::s_eventDowncastingFct[T::GetClassName()] = fct;
+            registerType(T::GetClassName(), fct);
         }
 
         template <class T>
         static void registerType(const std::string& s) {
 			sofa::core::objectmodel::Data<T> a; //Solve compilation for Windows, apparently force instanciation for Data<T> ???
-            s_dataCreationFct[s] = [](){ return new sofa::core::objectmodel::Data<T>(); };
+            registerType(s, [](){ return new sofa::core::objectmodel::Data<T>(); });
         }
 
         static std::map<std::string, componentDowncastingFunction>::iterator searchLowestCastAvailable(const sofa::core::objectmodel::BaseClass* metaclass);


### PR DESCRIPTION
Having static variables defined in multiple translation units is never a good idea. This was creating a linking error in OSX, which could only be fixed by adding a new linker flag.

This PR is a cleaner way to resolve this. Hopefully it will not break anything...