### PR TITLE
CMake python variables and documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,18 @@ if(NOT pybind11_FOUND)#
   return()
 endif()
 
+message("-- Python executable: ${PYTHON_EXECUTABLE}")
+message("-- Python version: ${PYBIND11_PYTHON_VERSION}")
 message("-- Python include dirs: ${PYTHON_INCLUDE_DIRS}")
 message("-- Python libraries: ${PYTHON_LIBRARIES}")
 message("-- Python library: ${PYTHON_LIBRARY}")
+
+# Unset the following variables to not confuse the user between the variables used by find_package(Python) and
+# those used by find_package(pybind11). The later only uses the output of find_package(Python).
+unset(PYTHON_EXECUTABLE)
+unset(PYTHON_INCLUDE_DIRS)
+unset(PYTHON_LIBRARIES)
+unset(PYTHON_LIBRARY)
 
 set(HEADER_FILES
     src/SofaPython3/config.h

--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ Add this directory path in `CMAKE_EXTERNAL_DIRECTORIES`.
 NB: This plugin cannot be build through in-build process when the old SofaPython plugin is activated. To have both SofaPython3 and SofaPython you need to use out-of-tree build. 
 
 ### Out-of-tree build
-This plugin should compile with out-of-tree builds
+This plugin should compile with out-of-tree builds.
+You might need to add the Sofa's installation path to the CMake prefix path. If you compiled Sofa in directory _$SOFA_ROOT/build_, consider doing an install step (make install, ninja install, etc.) and adding this installation path (example `cmake -DCMAKE_PREFIX_PATH=$SOFA_ROOT/build/install ..`).
+
+### Changing the python path
+The compilation of SofaPython3 plugin and bindings are tied to the python core library found during the CMake stage.
+To change the python version used for the compilation, you can either:
+1. Provide the python executable path with `Python_EXECUTABLE`
+ ```cmake -DPython_EXECUTABLE=/usr/local/bin/python3 ..```
+2. Provide the python root path with `Python_ROOT_DIR`
+ ```cmake -DPython_ROOT_DIR=/usr/local ..```
+
+To see all the hints that can be provided to CMake, see the official CMake documentation on Python :
+https://cmake.org/cmake/help/latest/module/FindPython.html
 
 ## Features
 


### PR DESCRIPTION
Remove the output CMake variables set by pybind11 to avoid confusion with the CMake variables the user can set to help CMake find the good python.

Add documentation on the readme to help the user change the path to its python.