### PR TITLE
Add  Sofa.Core.SofaPrefab

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CORE_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseData.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseObject.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseObject_doc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseCamera.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseCamera.h    
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Controller.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Controller_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_DataEngine.h
@@ -28,6 +28,8 @@ set(CORE_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_NodeIterator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Prefab.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Prefab_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataString.h
@@ -80,6 +82,7 @@ set(CORE_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_NodeIterator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_PythonScriptEvent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_BaseLink.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -413,7 +413,7 @@ py::list BindingBase::getLinks(Base& self)
     return list;
 }
 
-void BindingBase::addData(py::object py_self, const std::string& name, py::object value, py::object defaultValue, const std::string& help, const std::string& group, std::string type)
+BaseData* BindingBase::addData(py::object py_self, const std::string& name, py::object value, py::object defaultValue, const std::string& help, const std::string& group, std::string type)
 {
     Base* self = py::cast<Base*>(py_self);
     if (isProtectedKeyword(name))
@@ -477,24 +477,25 @@ void BindingBase::addData(py::object py_self, const std::string& name, py::objec
     data->setPersistent(true);
     if (!isSet)
         data->unset();
+    return data;
 }
 
-
-void BindingBase::addDataFromData(Base* self, py::object d)
+BaseData* BindingBase::addDataFromData(Base* self, py::object d)
 {
     BaseData* data = py::cast<BaseData*>(d);
     if (!data)
         throw py::type_error("Argument is not a Data!");
 
-    if (data->getOwner() == nullptr)
+    if (data->getOwner() == nullptr){
         self->addData(data, data->getName());
-    else
-    {
-        BaseData* newData = data->getNewInstance();
-        newData->setOwner(self);
-        newData->setParent(data);
-        newData->setName(data->getName());
+        return data;
     }
+
+    BaseData* newData = data->getNewInstance();
+    newData->setOwner(self);
+    newData->setParent(data);
+    newData->setName(data->getName());
+    return newData;
 }
 
 py::list BindingBase::__dir__(Base* self)

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.h
@@ -68,8 +68,8 @@ public:
 
     static py::list getDataFields(Base& self);
     static py::list getLinks(Base& self);
-    static void addData(py::object py_self, const std::string& name, py::object value = py::object(), py::object defaultValue = py::object(), const std::string& help = "", const std::string& group = "Property", std::string type = "");
-    static void addDataFromData(Base* self, py::object d);
+    static BaseData* addData(py::object py_self, const std::string& name, py::object value = py::object(), py::object defaultValue = py::object(), const std::string& help = "", const std::string& group = "Property", std::string type = "");
+    static BaseData* addDataFromData(Base* self, py::object d);
     static py::list __dir__(Base* self);
     static py::object __getattr__(py::object self, const std::string& s);
     static void __setattr__(py::object self, const std::string& s, py::object value);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp
@@ -1,0 +1,141 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#include <pybind11/pybind11.h>
+
+#include "Binding_Prefab.h"
+#include "Binding_Prefab_doc.h"
+
+#include <SofaPython3/DataHelper.h>
+#include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+#include <sofa/core/objectmodel/DataCallback.h>
+using sofa::core::objectmodel::DataCallback;
+
+#include <sofa/simulation/DeleteVisitor.h>
+
+PYBIND11_DECLARE_HOLDER_TYPE(Prefab,
+                             sofapython3::py_shared_ptr<Prefab>, true)
+
+namespace sofapython3
+{
+    using sofa::core::objectmodel::Event;
+
+    void Prefab::init()
+    {
+            reinit();
+    }
+
+    void Prefab::reinit()
+    {
+        /// remove everything in the node.
+            execute<sofa::simulation::DeleteVisitor>(sofa::core::ExecParams::defaultInstance());
+            doReInit();
+   }
+
+    void Prefab::doReInit()
+    {
+        std::cout << " PREFAB INSTANCE" << std::endl;
+    }
+
+    Prefab::Prefab() {
+        m_datacallback.addCallback( std::bind(&Prefab::reinit, this) );
+    }
+
+    Prefab::~Prefab() {
+    }
+
+    void Prefab::addPrefabParameter(const std::string& name, py::object value, const std::string& help, std::string type)
+    {
+        BaseData* data = BindingBase::addData(py::cast(this), name, value, py::object(), help, "Prefab's properties", type);
+        m_datacallback.addInputs({data});
+    }
+
+
+    class Prefab_Trampoline : public Prefab, public PythonTrampoline
+    {
+    public:
+        Prefab_Trampoline() = default;
+
+        ~Prefab_Trampoline() override = default;
+
+        std::string getClassName() const override
+        {
+            return pyobject->ob_type->tp_name;
+        }
+
+        void doReInit() override ;
+    };
+
+    void Prefab_Trampoline::doReInit()
+    {
+        PYBIND11_OVERLOAD(void, Prefab, doReInit, );
+    }
+
+    void moduleAddPrefab(py::module &m) {
+        py::class_<sofa::core::objectmodel::BasePrefab,
+                   sofa::simulation::Node,
+                   sofa::core::objectmodel::BasePrefab::SPtr>(m, "BasePrefab");
+
+        py::class_<Prefab,
+                Prefab_Trampoline,
+                BasePrefab,
+                py_shared_ptr<Prefab>> f(m, "Prefab",
+                                             py::dynamic_attr(),
+                                             py::multiple_inheritance(),
+                                             sofapython3::doc::prefab::Prefab);
+
+        f.def(py::init([](py::args& /*args*/, py::kwargs& kwargs)
+        {
+                  auto c = new Prefab_Trampoline();
+
+                  for(auto kv : kwargs)
+                  {
+                      std::string key = py::cast<std::string>(kv.first);
+                      py::object value = py::reinterpret_borrow<py::object>(kv.second);
+
+                      if( key == "name")
+                      c->setName(py::cast<std::string>(kv.second));
+                      try {
+                          BindingBase::SetAttr(*c, key, value);
+                      } catch (py::attribute_error& /*e*/) {
+                          /// kwargs are used to set datafields to their initial values,
+                          /// but they can also be used as simple python attributes, unrelated to SOFA.
+                          /// thus we catch & ignore the py::attribute_error thrown by SetAttr
+                      }
+                  }
+                  return c;
+              }));
+
+        f.def("addPrefabParameter", &Prefab::addPrefabParameter,
+                                    "name"_a, "value"_a, "help"_a, "type"_a);
+        f.def("init", &Prefab::init);
+        f.def("reinit", &Prefab::reinit);
+    }
+
+
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab.h
@@ -1,0 +1,72 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+#include "Binding_BaseObject.h"
+#include <sofa/core/objectmodel/DataCallback.h>
+#include <SofaSimulationGraph/DAGNode.h>
+
+namespace sofa::core::objectmodel
+{
+class BasePrefab : public sofa::simulation::graph::DAGNode
+{
+public:
+    SOFA_CLASS(BasePrefab, sofa::simulation::graph::DAGNode);
+};
+} /// namespace sofa::core::objectmodel
+
+template class pybind11::class_<sofa::core::objectmodel::BasePrefab,
+                                sofa::simulation::graph::DAGNode,
+                                sofa::core::sptr<sofa::core::objectmodel::BasePrefab>>;
+
+namespace sofapython3
+{
+using sofa::simulation::graph::DAGNode;
+using sofa::core::objectmodel::BasePrefab;
+using sofa::core::objectmodel::DataCallback;
+
+class Prefab : public BasePrefab
+{
+public:
+    SOFA_CLASS(Prefab, BasePrefab);
+    void init();
+    void reinit();
+    virtual void doReInit() ;
+
+    void addPrefabParameter(const std::string& name, py::object value, const std::string& help, std::string type);
+
+    Prefab();
+    ~Prefab() override;
+
+    DataCallback m_datacallback;
+};
+
+void moduleAddPrefab(py::module &m);
+
+} /// namespace sofapython3
+

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Prefab_doc.h
@@ -1,0 +1,35 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::prefab
+{
+static auto Prefab = R"(
+
+         )";
+}

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -41,6 +41,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include "Binding_DataEngine.h"
 #include "Binding_Node.h"
 #include "Binding_NodeIterator.h"
+#include "Binding_Prefab.h"
 #include "Binding_Simulation.h"
 #include "Binding_BaseLink.h"
 #include "Binding_PythonScriptEvent.h"
@@ -72,6 +73,7 @@ PYBIND11_MODULE(Core, core)
                Sofa.Core.Data
                Sofa.Core.Link
                Sofa.Core.Node
+               Sofa.Core.Prefab
                Sofa.Core.Object
                Sofa.Core.Camera
 
@@ -118,6 +120,7 @@ PYBIND11_MODULE(Core, core)
 
     moduleAddNode(core);
     moduleAddNodeIterator(core);
+    moduleAddPrefab(core);
     moduleAddBaseLink(core);
 
 }


### PR DESCRIPTION
Example of use:

```python
class MyPrefab(Sofa.Core.Prefab):
    def __init__(self, *args, **kwargs):
        Sofa.Core.Prefab.__init__(self, *args, **kwargs)
        self.addPrefabParameter(name="basename", value="Titi", type="string", help="Number of repetitions in the template")
        self.addPrefabParameter(name="n", value=4, type="int", help="Number of repetitions in the template")
        self.init()

    def doReInit(self):
        for i in range(self.n.value):
            self.addChild(self.basename.value+str(i))
```

The doReInit() function is called each time one of the registered prefab parameter change. The existing prefab content is destroyed and a new one is created. 

Warning: linking pointing to the prefab content will not be recreated. How to do ? 