### PR TITLE
Adding Empty Python Components in examples

### DIFF
--- a/examples/emptyController.py
+++ b/examples/emptyController.py
@@ -1,0 +1,44 @@
+import Sofa.Core
+
+class EmptyController(Sofa.Core.Controller):
+    """ custom %EmptyController% component for SOFA """
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.Controller.__init__(self, *args, **kwargs)
+        pass
+
+    def init():
+        pass
+    
+    def reinit():
+        pass
+    
+    # DEFAULT EVENTS:
+    def onAnimateBeginEvent(self, event):
+        """ called at the beginning of each time step """
+        pass
+
+    def onAnimateEndEvent(self, event):
+        """ called at the end of each time step """
+        pass
+
+    def onKeypressedEvent(self, event):
+        """ called when a key release event is triggered from the UI """
+        pass
+
+    def onKeyreleasedEvent(self, event):
+        """ called when a key release event is triggered from the UI """
+        pass
+
+    def onMouseEvent(self, event):
+        """ called when a mouse event is triggered from the UI """
+        pass
+
+    def onScriptEvent(self, event):
+        """ catches events sent from other python scripts """
+        pass
+
+    def onEvent(self, event):
+        """ generic method called when no script method exists for the sent event """
+        pass
+

--- a/examples/emptyDataEngine.py
+++ b/examples/emptyDataEngine.py
@@ -1,0 +1,22 @@
+import Sofa.Core
+from Sofa.Helper import msg_info
+
+
+class EmptyDataEngine(Sofa.Core.DataEngine):
+    """ custom %EmptyDataEngine% component for SOFA """
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.DataEngine.__init__(self, *args, **kwargs)
+        pass
+
+    def init():
+        pass
+
+    def update():
+        """
+        called anytime an output is accessed while the component
+        is dirty (input has changed)
+        """
+        msg_info('Not implemented yet')
+        pass
+    

--- a/examples/emptyForceField.py
+++ b/examples/emptyForceField.py
@@ -1,0 +1,24 @@
+import Sofa.Core
+import numpy as np
+from Sofa.Helper import msg_info
+
+class EmptyForcefield(Sofa.Core.ForceField):
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.ForceField.__init__(self, *args, **kwargs)
+        pass
+
+    def init(self):
+        pass
+
+    def addForce(self, m, forces, pos, vel):
+        msg_info('Not implemented yet')
+        pass
+
+    def addDForce(self, m, dforce, dx):
+        msg_info('Not implemented yet')
+        pass
+
+    def addKToMatrix(self, mparams, nNodes, nDofs):
+        msg_info('Not implemented yet')
+        pass
+


### PR DESCRIPTION
Just 3 empty scripts showing the signatures of the bound python methods for:
Sofa.Core.Controller
Sofa.Core.DataEngine
Sofa.Core.ForceField