### PR TITLE
Remove the automatic reload of the scene module

### DIFF
--- a/src/SofaPython3/PythonEnvironment.cpp
+++ b/src/SofaPython3/PythonEnvironment.cpp
@@ -154,11 +154,7 @@ SOFAPYTHON3_API py::module PythonEnvironment::importFromFile(const std::string& 
                                               globals,
                                               locals);
     py::module m =  py::cast<py::module>(locals["new_module"]);
-    m.reload();
     return m;
-    //py::module m = py::module::import(module.c_str());
-    //m.reload();
-    //return m;
 }
 
 


### PR DESCRIPTION
Loading a python scene will load two times the scene file.

**test.py**
```
#!/usr/bin/python3
print("hello there")
def createScene(root):
    pass
```

**output**
```
$ runSofa test.py
(...)
[INFO]    [SofaPython3] Importing module: test.py
hello there
hello there
(...)
```

This is because, for some reason, the `PythonEnvironment` will first load the scene file as a python module, and than force a reload on it.