### PR TITLE
Fix SofaBaseTopology module name and import path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(SofaFramework REQUIRED)
 find_package(SofaSimulation REQUIRED)
 find_package(SofaGeneral REQUIRED)
+find_package(SofaComponentGeneral REQUIRED)
 
 
 unset(PYTHON_EXECUTABLE)

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/CMakeLists.txt
@@ -25,5 +25,5 @@ SP3_add_python_module(
     DEPENDS
         SofaBaseTopology SofaPython3
     DESTINATION
-        ${SP3_PYTHON_PACKAGES_DIRECTORY}
+        ${SP3_PYTHON_PACKAGES_DIRECTORY}/Sofa
 )

--- a/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
+++ b/bindings/Modules/src/SofaPython3/SofaBaseTopology/Module_SofaBaseTopology.cpp
@@ -35,7 +35,7 @@ namespace py { using namespace pybind11; }
 namespace sofapython3
 {
 
-PYBIND11_MODULE(SofaBaseTopology, m)
+PYBIND11_MODULE(BaseTopology, m)
 {
     moduleAddRegularGridTopology(m);
     moduleAddSparseGridTopology(m);


### PR DESCRIPTION
#108 changed the module name SofaBaseTopology to BaseTopology but did not propagate the change inside the init function of the module, which created a linked error when importing the module (I'm looking at you, @fredroy).

This PR fixes this, and also move the module into the Sofa package. Now, instead of doing
```
import BaseTopology
```
which doesn't make it clear that this is a Sofa package, you do:
```
from Sofa import BaseTopology
``` 