### PR TITLE
[Core] Add bindings of the ObjectFactory

### DIFF
--- a/bindings/Sofa/CMakeLists.txt
+++ b/bindings/Sofa/CMakeLists.txt
@@ -27,6 +27,8 @@ set(CORE_HEADER_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_ForceField_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor_doc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_ObjectFactory_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node_doc.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_NodeIterator.h
@@ -84,6 +86,7 @@ set(CORE_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Data/Binding_DataVectorString.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_ForceField.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Visitor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Node.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_NodeIterator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/SofaPython3/Sofa/Core/Binding_Prefab.cpp

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.cpp
@@ -1,0 +1,200 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#include "Binding_ObjectFactory.h"
+#include "Binding_ObjectFactory_doc.h"
+#include <numeric>
+#include <sstream>
+#include <pybind11/stl.h>
+
+using sofa::core::ObjectFactory;
+namespace py { using namespace pybind11; }
+
+namespace sofapython3 {
+
+std::string __repr__(const ObjectFactory::ClassEntry & entry) {
+    std::ostringstream s;
+    s << "<" << entry.className << " at " << std::hex << &entry << ">";
+    return s.str();
+}
+
+std::string __str__(const ObjectFactory::ClassEntry & entry) {
+    std::string desc;
+    desc += "Component '" + entry.className + "' \n";
+    desc += "  Description: " + entry.description + "\n";
+    desc += "  Authors: " + entry.authors + "\n";
+
+    std::string aliases = entry.aliases.empty() ? "None" :
+        std::accumulate(std::next(entry.aliases.begin()), entry.aliases.end(), *(entry.aliases.begin()),
+                        [](std::string a, const std::string &b) {
+                            return std::move(a) + ", " + b;
+                        }
+        );
+    desc += "  Aliases: " + aliases + "\n";
+
+    std::set<std::string> templates;
+    std::set<std::string> targets;
+    std::set<std::string> locations;
+    std::string default_template = entry.defaultTemplate;
+    for (const auto & creator : entry.creatorMap) {
+        if (not creator.first.empty())
+            templates.emplace(creator.first);
+        if (creator.second) {
+            if (not std::string(creator.second->getTarget()).empty())
+                targets.emplace(creator.second->getTarget());
+            if (not std::string(creator.second->getHeaderFileLocation()).empty())
+                locations.emplace(creator.second->getHeaderFileLocation());
+        }
+    }
+    std::string templates_str = templates.empty() ? "None" :
+        std::accumulate(std::next(templates.begin()), templates.end(), "'"+*(templates.begin())+"'",
+                        [&default_template](std::string a, const std::string & b) {
+                            return std::move(a) + ", '" + b + (b == default_template ? "' (default)" : "'");
+                        }
+        );
+    desc += "  Templates: " + templates_str + "\n";
+
+    std::string targets_str = targets.empty() ? "None" :
+                              std::accumulate(std::next(targets.begin()), targets.end(), *(targets.begin()),
+                                              [](std::string a, const std::string &b) {
+                                                  return std::move(a) + ", " + b;
+                                              }
+                              );
+    desc += "  Targets: " + targets_str + "\n";
+
+    std::string location_str = locations.empty() ? "None" :
+                              std::accumulate(std::next(locations.begin()), locations.end(), "\n    "+*(locations.begin()),
+                                              [](std::string a, const std::string &b) {
+                                                  return std::move(a) + "\n    " + b;
+                                              }
+                              );
+    desc += "  Locations: " + location_str;
+
+    return desc;
+}
+
+std::set<std::string> getTargets(ObjectFactory& f) {
+    std::set<std::string> targets;
+    std::vector<ObjectFactory::ClassEntry::SPtr> entries;
+    f.getAllEntries(entries);
+    for (const auto & entry : entries) {
+        for (const auto & creator : entry->creatorMap) {
+            if (not std::string(creator.second->getTarget()).empty())
+                targets.emplace(creator.second->getTarget());
+        }
+    }
+    return targets;
+}
+
+std::set<std::string> getTemplates(const ObjectFactory::ClassEntry &entry) {
+    std::set<std::string> templates;
+    for (const auto & creator : entry.creatorMap) {
+        if (not creator.first.empty())
+            templates.emplace(creator.first);
+    }
+    return templates;
+}
+
+std::set<std::string> getTargetsOfEntry(const ObjectFactory::ClassEntry &entry) {
+    std::set<std::string> targets;
+    for (const auto & creator : entry.creatorMap) {
+        if (not creator.first.empty())
+            if (creator.second and not std::string(creator.second->getTarget()).empty()) {
+                targets.emplace(creator.second->getTarget());
+            }
+    }
+    return targets;
+}
+
+std::set<std::string> getLocationsOfEntry(const ObjectFactory::ClassEntry &entry) {
+    std::set<std::string> locations;
+    for (const auto & creator : entry.creatorMap) {
+        if (not creator.first.empty())
+            if (creator.second and not std::string(creator.second->getHeaderFileLocation()).empty()) {
+                locations.emplace(creator.second->getHeaderFileLocation());
+            }
+    }
+    return locations;
+}
+
+void moduleAddObjectFactory(py::module &m) {
+    py::class_<ObjectFactory> factory (m, "ObjectFactory", sofapython3::doc::objectmodel::ObjectFactoryClass);
+
+    py::class_<ObjectFactory::ClassEntry> entry(m, sofapython3::doc::objectmodel::ClassEntryClass);
+    entry.def_readonly("className", &ObjectFactory::ClassEntry::className);
+    entry.def_readonly("aliases", &ObjectFactory::ClassEntry::aliases);
+    entry.def_readonly("description", &ObjectFactory::ClassEntry::description);
+    entry.def_readonly("authors", &ObjectFactory::ClassEntry::authors);
+    entry.def_readonly("license", &ObjectFactory::ClassEntry::license);
+    entry.def_readonly("defaultTemplate", &ObjectFactory::ClassEntry::defaultTemplate);
+    entry.def_readonly("dataAlias", &ObjectFactory::ClassEntry::m_dataAlias);
+    entry.def_property_readonly("templates", &getTemplates);
+    entry.def_property_readonly("targets", &getTargetsOfEntry);
+    entry.def_property_readonly("locations", &getLocationsOfEntry);
+
+    entry.def("__str__", &__str__);
+    entry.def("__repr__", &__repr__);
+
+
+    factory.def_static("getComponent", [](const std::string & component_name) {
+        return ObjectFactory::getInstance()->getEntry(component_name);
+    }, doc::objectmodel::ObjectFactory_getEntry);
+
+    factory.def_static("shortName", [](const std::string & component_name) {
+        return ObjectFactory::getInstance()->shortName(component_name);
+    }, doc::objectmodel::ObjectFactory_shortName);
+
+    factory.def_property_readonly_static("components", [](const py::object &) {
+        std::vector<ObjectFactory::ClassEntry::SPtr> entries;
+        ObjectFactory::getInstance()->getAllEntries(entries);
+        // Copy all entries since the pointers will be deleted
+        std::vector<ObjectFactory::ClassEntry> returned_entries;
+        returned_entries.reserve(entries.size());
+        for (const ObjectFactory::ClassEntry::SPtr & entry : entries) {
+            returned_entries.push_back(*entry);
+        }
+        return returned_entries;
+    }, doc::objectmodel::ObjectFactory_getAllEntries);
+
+    factory.def_static("getComponentsFromTarget", [](const std::string & target_name) {
+        std::vector<ObjectFactory::ClassEntry::SPtr> entries;
+        ObjectFactory::getInstance()->getEntriesFromTarget(entries, target_name);
+        // Copy all entries since the pointers will be deleted
+        std::vector<ObjectFactory::ClassEntry> returned_entries;
+        returned_entries.reserve(entries.size());
+        for (const ObjectFactory::ClassEntry::SPtr & entry : entries) {
+            returned_entries.push_back(*entry);
+        }
+        return returned_entries;
+    }, doc::objectmodel::ObjectFactory_getEntriesFromTarget);
+
+    factory.def_property_readonly_static("targets", [](const py::object &){
+        return getTargets(*ObjectFactory::getInstance());
+    }, doc::objectmodel::ObjectFactory_targets);
+}
+
+} /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.h
@@ -1,0 +1,37 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+#include <sofa/core/ObjectFactory.h>
+#include <pybind11/pybind11.h>
+
+namespace sofapython3 {
+
+void moduleAddObjectFactory(pybind11::module &m);
+
+} ///sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory_doc.h
@@ -1,0 +1,76 @@
+/*********************************************************************
+Copyright 2019, CNRS, University of Lille, INRIA
+
+This file is part of sofaPython3
+
+sofaPython3 is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaPython3 is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************/
+/********************************************************************
+ Contributors:
+    - damien.marchal@univ-lille.fr
+    - bruno.josue.marques@inria.fr
+    - eve.le-guillou@centrale.centralelille.fr
+    - jean-nicolas.brunet@inria.fr
+    - thierry.gaugry@inria.fr
+********************************************************************/
+
+#pragma once
+
+namespace sofapython3::doc::objectmodel {
+static auto ObjectFactoryClass =
+    R"(
+    Main class used to register and dynamically create objects.
+
+    It uses the Factory design pattern, where each class is registered in a map,
+    and dynamically retrieved given the type name.
+
+    It also stores metainformation on each classes, such as description,
+    authors, license, and available template types.
+    )";
+
+static auto ClassEntryClass =
+    R"(
+    Record storing information about a class
+    )";
+
+static auto ObjectFactory_getEntry =
+    R"(
+    Get an entry given a class name (or alias)
+    )";
+
+static auto ObjectFactory_shortName =
+    R"(
+    Return the shortname for this classname. Empty string if no creator exists for this classname.
+    )";
+
+static auto ObjectFactory_getAllEntries =
+    R"(
+    Return all the registered classes
+    )";
+
+static auto ObjectFactory_getEntriesFromTarget =
+    R"(
+    Return the registered classes from a given target
+    )";
+
+static auto ObjectFactory_targets =
+    R"(
+    Targets which contains a set of components. For example, the target 'SofaBaseMechanics'.
+    )";
+
+static auto ObjectFactory_getInstance =
+    R"(
+    Get the ObjectFactory singleton instance
+    )";
+} /// namespace sofapython3::doc::forceField

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Submodule_Core.cpp
@@ -41,6 +41,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include "Binding_Context.h"
 #include "Binding_Controller.h"
 #include "Binding_DataEngine.h"
+#include "Binding_ObjectFactory.h"
 #include "Binding_Node.h"
 #include "Binding_NodeIterator.h"
 #include "Binding_Prefab.h"
@@ -121,6 +122,7 @@ PYBIND11_MODULE(Core, core)
     moduleAddController(core);
     moduleAddDataEngine(core);
     moduleAddForceField(core);
+    moduleAddObjectFactory(core);
 
     moduleAddNode(core);
     moduleAddNodeIterator(core);


### PR DESCRIPTION
Following [this thread](https://www.sofa-framework.org/community/forum/topic/available-objects-in-the-factory-python-or-xml/), here's a new way to get the available components and some informations about them.

Unless I'm mistaking, it is however not possible to get the list of Data of a component without instantiating it first.

![image](https://user-images.githubusercontent.com/6951981/76527455-8d1f2f00-646f-11ea-8e0a-49965a94e9e1.png)
