### PR TITLE
Fix compilation with Windows and (rare) problematic case

### DIFF
--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -64,8 +64,9 @@ function(SP3_add_python_module)
     endif ()
 
     # Fetch the current path relative to /bindings/*/src
+    # Must test if the result is nested into the CMAKE_CURRENT_SOURCE_DIR (case where src exists outside the plugin directory)
     string(REGEX MATCH "(.*)/src" path_to_src "${CMAKE_CURRENT_SOURCE_DIR}")
-    if (NOT path_to_src AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src")
+    if ( ( NOT path_to_src OR "${path_to_src}" STRLESS "${CMAKE_CURRENT_SOURCE_DIR}" ) AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src" )
         set(path_to_src "${CMAKE_CURRENT_SOURCE_DIR}/src")
     endif()
 

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_ObjectFactory.cpp
@@ -61,12 +61,12 @@ std::string __str__(const ObjectFactory::ClassEntry & entry) {
     std::set<std::string> locations;
     std::string default_template = entry.defaultTemplate;
     for (const auto & creator : entry.creatorMap) {
-        if (not creator.first.empty())
+        if (! creator.first.empty())
             templates.emplace(creator.first);
         if (creator.second) {
-            if (not std::string(creator.second->getTarget()).empty())
+            if (! std::string(creator.second->getTarget()).empty())
                 targets.emplace(creator.second->getTarget());
-            if (not std::string(creator.second->getHeaderFileLocation()).empty())
+            if (! std::string(creator.second->getHeaderFileLocation()).empty())
                 locations.emplace(creator.second->getHeaderFileLocation());
         }
     }
@@ -103,7 +103,7 @@ std::set<std::string> getTargets(ObjectFactory& f) {
     f.getAllEntries(entries);
     for (const auto & entry : entries) {
         for (const auto & creator : entry->creatorMap) {
-            if (not std::string(creator.second->getTarget()).empty())
+            if (! std::string(creator.second->getTarget()).empty())
                 targets.emplace(creator.second->getTarget());
         }
     }
@@ -113,7 +113,7 @@ std::set<std::string> getTargets(ObjectFactory& f) {
 std::set<std::string> getTemplates(const ObjectFactory::ClassEntry &entry) {
     std::set<std::string> templates;
     for (const auto & creator : entry.creatorMap) {
-        if (not creator.first.empty())
+        if (! creator.first.empty())
             templates.emplace(creator.first);
     }
     return templates;
@@ -122,8 +122,8 @@ std::set<std::string> getTemplates(const ObjectFactory::ClassEntry &entry) {
 std::set<std::string> getTargetsOfEntry(const ObjectFactory::ClassEntry &entry) {
     std::set<std::string> targets;
     for (const auto & creator : entry.creatorMap) {
-        if (not creator.first.empty())
-            if (creator.second and not std::string(creator.second->getTarget()).empty()) {
+        if (! creator.first.empty())
+            if (creator.second && ! std::string(creator.second->getTarget()).empty()) {
                 targets.emplace(creator.second->getTarget());
             }
     }
@@ -133,8 +133,8 @@ std::set<std::string> getTargetsOfEntry(const ObjectFactory::ClassEntry &entry) 
 std::set<std::string> getLocationsOfEntry(const ObjectFactory::ClassEntry &entry) {
     std::set<std::string> locations;
     for (const auto & creator : entry.creatorMap) {
-        if (not creator.first.empty())
-            if (creator.second and not std::string(creator.second->getHeaderFileLocation()).empty()) {
+        if (! creator.first.empty())
+            if (creator.second && ! std::string(creator.second->getHeaderFileLocation()).empty()) {
                 locations.emplace(creator.second->getHeaderFileLocation());
             }
     }


### PR DESCRIPTION
Fix the usual compilation with Windows (and & not keyword)
and fix the case where the SofaPython plugin is located into a path containing a src string.