### PR TITLE
Add binding method to get all input / output datafields of a DataEngine

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -46,6 +46,7 @@ namespace sofapython3
     using sofa::core::objectmodel::BaseObject;
     using sofa::core::objectmodel::DDGNode;
 
+
     void PyDataEngine::init() {
         std::cout << "PyDataEngine::init()" << std::endl;
     }
@@ -100,6 +101,30 @@ namespace sofapython3
         throw py::type_error(this->getName() + " has no update() method.");
     }
 
+
+    py::list property_inputs(DataEngine* self)
+    {
+        py::list list;
+        auto fields = self->getDataFields();
+        auto it = std::remove_if(fields.begin(), fields.end(), [&](const auto & data){ return data->getGroup() != "Inputs"; });
+        fields.erase(it, fields.end());
+        for(auto i : fields)
+            list.append(PythonFactory::toPython(i));
+        return list;
+    }
+
+    py::list property_outputs(DataEngine* self)
+    {
+        py::list list;
+        auto fields = self->getDataFields();
+        auto it = std::remove_if(fields.begin(), fields.end(), [&](const auto & data){ return data->getGroup() != "Inputs"; });
+        fields.erase(it, fields.end());
+        for(auto i : fields)
+            list.append(PythonFactory::toPython(i));
+        return list;
+    }
+
+
     void moduleAddDataEngine(pybind11::module &m)
     {
         py::class_<PyDataEngine,
@@ -133,6 +158,8 @@ namespace sofapython3
 
         f.def("addInput", &PyDataEngine::addInput, sofapython3::doc::dataengine::addInput);
         f.def("addOutput", &PyDataEngine::addOutput, sofapython3::doc::dataengine::addOutput);
+        f.def_property_readonly("inputs", &property_inputs);
+        f.def_property_readonly("outputs", &property_outputs);
     }
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.cpp
@@ -94,18 +94,18 @@ namespace sofapython3
             try {
                 fct();
                 return;
-            } catch (std::exception& /*e*/) {
-                throw py::type_error(this->getName() + ": The DataEngine requires an update method with no parameter and no return type");
+            } catch (std::exception& e) {
+                throw py::type_error(this->getName() + ": The DataEngine requires an update method with no parameter and no return type\n" + e.what());
             }
         }
         throw py::type_error(this->getName() + " has no update() method.");
     }
 
 
-    py::list property_inputs(DataEngine* self)
+    py::list PyDataEngine::inputs()
     {
         py::list list;
-        auto fields = self->getDataFields();
+        auto fields = getDataFields();
         auto it = std::remove_if(fields.begin(), fields.end(), [&](const auto & data){ return data->getGroup() != "Inputs"; });
         fields.erase(it, fields.end());
         for(auto i : fields)
@@ -113,10 +113,10 @@ namespace sofapython3
         return list;
     }
 
-    py::list property_outputs(DataEngine* self)
+    py::list PyDataEngine::outputs()
     {
         py::list list;
-        auto fields = self->getDataFields();
+        auto fields = getDataFields();
         auto it = std::remove_if(fields.begin(), fields.end(), [&](const auto & data){ return data->getGroup() != "Inputs"; });
         fields.erase(it, fields.end());
         for(auto i : fields)
@@ -158,8 +158,8 @@ namespace sofapython3
 
         f.def("addInput", &PyDataEngine::addInput, sofapython3::doc::dataengine::addInput);
         f.def("addOutput", &PyDataEngine::addOutput, sofapython3::doc::dataengine::addOutput);
-        f.def_property_readonly("inputs", &property_inputs);
-        f.def_property_readonly("outputs", &property_outputs);
+        f.def("inputs", &PyDataEngine::inputs);
+        f.def("outputs", &PyDataEngine::outputs);
     }
 
 } /// namespace sofapython3

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_DataEngine.h
@@ -53,6 +53,8 @@ public:
     PyDataEngine();
     ~PyDataEngine() override;
 
+    py::list inputs();
+    py::list outputs();
 };
 
 void moduleAddDataEngine(pybind11::module &m);


### PR DESCRIPTION
just 2 new methods retrieving all datafields belonging to the "Inputs" or "Outputs" group of DataEngines.
in terms of impl, I hesitated between:

1. using DataEngine::getInputs() to retrieve all input DDGNodes, then returning those of them that are BaseData: this approach could catch input datafields that do not belong to the engine, which I don't think is a good practice
2. use getDataFields() method of Base to retrieve all datafields, then returning those that belong to the "Inputs" group. this only returns datafields owned by the engine, but might cause issues if an input's group is forcibly changed in the code (dunno why that would be done, but technically possible...) 

I went for the latter, but I'm not sure that's what we want
BTW, any particular reason why we preferred using a function call rather than a read only property for getDataFields() in Binding_Base.cpp @damienmarchal ? I went the other way for this PR, but I can change that of course

Also, I can't seem to be able to PR from this repo to the forked repo on sofa-framework.. The other way around works fine. do you know how to reverse the link direction? :D