### PR TITLE
ADD: resize method on DataContainers + tests

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer_doc.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Data/Binding_DataContainer_doc.h
@@ -58,4 +58,23 @@ static auto shape =
         with each value being equal to the length of the given dimension)
         )";
 
+static auto resize =
+        R"(Resize data to newSize elements, if relevant.
+
+        But resizing is not always relevant, for example:
+        - nothing happens if FixedSize() is true;
+        - sets can't be resized; they are cleared instead;
+        - nothing happens for vectors containing resizable values (i.e. when
+          BaseType()::FixedSize() is false), because of the 'single index' abstraction;
+
+        Returns true iff the data was resizable
+        )";
+
+static auto append =
+        R"(appends value to data, if possible.
+        The success of this operation depends on wether the container is resizeable
+        (see DataContainer::resize).
+
+        Returns true iff the value was added.
+        )";
 }  // namespace sofapython3::doc::datacontainer

--- a/bindings/Sofa/tests/Core/BaseData.py
+++ b/bindings/Sofa/tests/Core/BaseData.py
@@ -408,3 +408,24 @@ class Test(unittest.TestCase):
         self.assertFalse(data.isReadOnly())
         data.setReadOnly(True)
         self.assertTrue(data.isReadOnly())
+
+    def test_DataContainer_resize(self):
+        root = Sofa.Core.Node('root')
+        mo = root.addObject("MechanicalObject", name="mo", position=[[1,2,3], [4,5,6]])
+        mo.position.resize(3);
+        self.assertEqual(len(mo.position), 3)
+        self.assertEqual(mo.position.size, 3*3)
+
+    def test_DataContainer_setitem(self):
+        root = Sofa.Core.Node('root')
+        mo = root.addObject("MechanicalObject", name="mo", position=[[1,2,3], [4,5,6]])
+        mo.position[0] = [3,2,1]
+        self.assertEqual(mo.position.toList(), [[3,2,1],[4,5,6]])
+        mo.position[0,1] = 42
+        self.assertEqual(mo.position.toList(), [[1,42,3],[4,5,6]])
+
+    def test_DataContainer_append(self):
+        root = Sofa.Core.Node('root')
+        mo = root.addObject("MechanicalObject", name="mo", position=[[1,2,3], [4,5,6]])
+        mo.position.append([7,8,9])
+        self.assertEqual(mo.position.toList(), [[1,2,3],[4,5,6],[7,8,9]])


### PR DESCRIPTION
 This PR adds a "resize" binding function for DataContainers, to change the dimension of C++ arrays from python.
While trying to also add an "append" function, I've noticed that the \__setitem\__ binding does not appear to be implemented to handle assignment of non-scalar elements.

Basically, on a 2D vector:
```py
DataContainer[0,0] = 42 # works fine
DataContainer[0] = [1,2,3] # RuntimeError, could not convert list to c++ type
```
So I also added a test to show that behavior.

I'll add the code for range assignment and for the append method asap